### PR TITLE
fix(Dropzone): dropzoneのファイル名省略

### DIFF
--- a/src/dropzone/Dropzone.tsx
+++ b/src/dropzone/Dropzone.tsx
@@ -34,14 +34,15 @@ export const Dropzone: React.VFC<DropzoneProps> = ({
     >
       <input {...getInputProps()} />
       {files.length > 0 ? (
-        <div>
+        <div tw="w-full flex justify-center">
           {files.map((file) => (
-            <div key={file.name} tw="flex justify-center items-center">
-              <div tw="mr-2">{file.name}</div>
+            <div key={file.name} tw="flex justify-center items-center w-4/5">
+              <div tw="mr-2 truncate">{file.name}</div>
               <Button
                 onClick={(e) => onRemove(file)(e)}
                 color="danger"
                 variant="text"
+                twin={[tw`flex-shrink-0 flex-grow-0`]}
               >
                 <MdClose size={24} />
               </Button>
@@ -49,7 +50,7 @@ export const Dropzone: React.VFC<DropzoneProps> = ({
           ))}
         </div>
       ) : (
-        <div tw="flex flex-col items-center text-middle">
+        <div tw="w-full flex flex-col items-center text-middle">
           <MdFileUpload size={48} tw="mb-3" />
           <p tw="text-middle">{message}</p>
         </div>


### PR DESCRIPTION
### monday

- 

### preview

- 
![スクリーンショット 2021-08-04 16 41 55](https://user-images.githubusercontent.com/24839973/128142510-39c209e9-930a-4d79-92b2-ff1e2267aaad.png)


### 実装内容
ファイル名が長すぎる場合に、省略するようにしました。
### 相談内容(あれば)
