### PR TITLE
chore(package.json):exportsフィールドを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
   "module": "dist/index.esm.js",
   "browser": "dist/index.js",
   "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    },
+    "./tailwind.config.cjs": "./tailwind.config.cjs"
+  },
   "author": "locona <miyamae@3-shake.com>",
   "sideEffects": false,
   "engines": {


### PR DESCRIPTION
### monday

- 

### preview

- 

### 実装内容
rollupでesm/cjs/umdにそれぞれビルドしているのですが、package.jsonのexportsフィールドがないため、webpackが認識できていないです。解決のためexportsフィールドを定義しました。これで認識してくれる......はずです。

### 相談内容(あれば)
