### PR TITLE
fix(eslint-config): Reactのversionを検出するように修正

### DIFF
--- a/.changeset/six-crews-punch.md
+++ b/.changeset/six-crews-punch.md
@@ -1,0 +1,5 @@
+---
+"@4design/eslint-config": patch
+---
+
+fix(eslint-config): Reactのversionをdetectするように修正

--- a/packages/eslint-config/src/react.cjs
+++ b/packages/eslint-config/src/react.cjs
@@ -22,6 +22,11 @@ module.exports = {
         'react/react-in-jsx-scope': 'off', // import of React is no longer required starting from react@17
         'tailwindcss/no-custom-classname': 'off',
       },
+      settings: {
+        react: {
+          version: 'detect',
+        },
+      },
     },
     {
       files: [


### PR DESCRIPTION
## チケット

- Close #900 

## 実装内容

- warningが出ていたeslintがreactのversionを特定できない問題を修正
  - `Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration .`

## スクリーンショット

変更なしのため割愛

## 相談内容(あれば)

-
