### PR TITLE
fix(Button): テキストのサイズダウンに伴うスタイル修正

### DIFF
--- a/.changeset/spicy-rice-whisper.md
+++ b/.changeset/spicy-rice-whisper.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": minor
+---
+
+fix(Button): テキストのサイズダウンに伴うスタイル修正

--- a/packages/for-ui/src/button/Button.stories.tsx
+++ b/packages/for-ui/src/button/Button.stories.tsx
@@ -92,29 +92,29 @@ export const Filled = (): JSX.Element => (
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button size="medium" variant="contained" startIcon={<MdAdd size={20} />}>
+          <Button size="medium" variant="contained" startIcon={<MdAdd size={16} />}>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" startIcon={<MdAdd size={20} />} disabled>
+          <Button size="medium" variant="contained" startIcon={<MdAdd size={16} />} disabled>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" startIcon={<MdAdd size={20} />} loadingPosition="start" loading>
+          <Button size="medium" variant="contained" startIcon={<MdAdd size={16} />} loadingPosition="start" loading>
             登録する
           </Button>
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button size="medium" variant="contained" endIcon={<MdEdit size={20} />}>
+          <Button size="medium" variant="contained" endIcon={<MdEdit size={16} />}>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" endIcon={<MdEdit size={20} />} disabled>
+          <Button size="medium" variant="contained" endIcon={<MdEdit size={16} />} disabled>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" endIcon={<MdEdit size={20} />} loadingPosition="end" loading>
+          <Button size="medium" variant="contained" endIcon={<MdEdit size={16} />} loadingPosition="end" loading>
             登録する
           </Button>
         </div>
@@ -194,29 +194,29 @@ export const Contained = (): JSX.Element => (
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button size="medium" variant="contained" startIcon={<MdAdd size={20} />}>
+          <Button size="medium" variant="contained" startIcon={<MdAdd size={16} />}>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" startIcon={<MdAdd size={20} />} disabled>
+          <Button size="medium" variant="contained" startIcon={<MdAdd size={16} />} disabled>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" startIcon={<MdAdd size={20} />} loadingPosition="start" loading>
+          <Button size="medium" variant="contained" startIcon={<MdAdd size={16} />} loadingPosition="start" loading>
             登録する
           </Button>
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button size="medium" variant="contained" endIcon={<MdEdit size={20} />}>
+          <Button size="medium" variant="contained" endIcon={<MdEdit size={16} />}>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" endIcon={<MdEdit size={20} />} disabled>
+          <Button size="medium" variant="contained" endIcon={<MdEdit size={16} />} disabled>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" endIcon={<MdEdit size={20} />} loadingPosition="end" loading>
+          <Button size="medium" variant="contained" endIcon={<MdEdit size={16} />} loadingPosition="end" loading>
             登録する
           </Button>
         </div>
@@ -296,29 +296,29 @@ export const Outlined = (): JSX.Element => (
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button size="medium" variant="outlined" startIcon={<MdAdd size={20} />}>
+          <Button size="medium" variant="outlined" startIcon={<MdAdd size={16} />}>
             登録する
           </Button>
 
-          <Button size="medium" variant="outlined" startIcon={<MdAdd size={20} />} disabled>
+          <Button size="medium" variant="outlined" startIcon={<MdAdd size={16} />} disabled>
             登録する
           </Button>
 
-          <Button size="medium" variant="outlined" startIcon={<MdAdd size={20} />} loadingPosition="start" loading>
+          <Button size="medium" variant="outlined" startIcon={<MdAdd size={16} />} loadingPosition="start" loading>
             登録する
           </Button>
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button size="medium" variant="outlined" endIcon={<MdEdit size={20} />}>
+          <Button size="medium" variant="outlined" endIcon={<MdEdit size={16} />}>
             登録する
           </Button>
 
-          <Button size="medium" variant="outlined" endIcon={<MdEdit size={20} />} disabled>
+          <Button size="medium" variant="outlined" endIcon={<MdEdit size={16} />} disabled>
             登録する
           </Button>
 
-          <Button size="medium" variant="outlined" endIcon={<MdEdit size={20} />} loadingPosition="end" loading>
+          <Button size="medium" variant="outlined" endIcon={<MdEdit size={16} />} loadingPosition="end" loading>
             登録する
           </Button>
         </div>
@@ -398,79 +398,29 @@ export const _Text = (): JSX.Element => (
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button size="medium" variant="text" startIcon={<MdAdd size={20} />}>
+          <Button size="medium" variant="text" startIcon={<MdAdd size={16} />}>
             登録する
           </Button>
 
-          <Button size="medium" variant="text" startIcon={<MdAdd size={20} />} disabled>
+          <Button size="medium" variant="text" startIcon={<MdAdd size={16} />} disabled>
             登録する
           </Button>
 
-          <Button size="medium" variant="text" startIcon={<MdAdd size={20} />} loadingPosition="start" loading>
-            登録する
-          </Button>
-        </div>
-
-        <div className="flex flex-col gap-4">
-          <Button size="medium" variant="text" endIcon={<MdEdit size={20} />}>
-            登録する
-          </Button>
-
-          <Button size="medium" variant="text" endIcon={<MdEdit size={20} />} disabled>
-            登録する
-          </Button>
-
-          <Button size="medium" variant="text" endIcon={<MdEdit size={20} />} loadingPosition="end" loading>
-            登録する
-          </Button>
-        </div>
-      </div>
-    </div>
-
-    <div>
-      <div className="mb-4 border-b">
-        <Text variant="h3">Button/Text/Small</Text>
-      </div>
-
-      <div className="flex flex-row gap-8">
-        <div className="flex flex-col gap-4">
-          <Button variant="text" size="small">
-            登録する
-          </Button>
-
-          <Button variant="text" size="small" disabled>
-            登録する
-          </Button>
-
-          <Button variant="text" size="small" loading>
+          <Button size="medium" variant="text" startIcon={<MdAdd size={16} />} loadingPosition="start" loading>
             登録する
           </Button>
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button variant="text" size="small" startIcon={<MdAdd size={20} />}>
+          <Button size="medium" variant="text" endIcon={<MdEdit size={16} />}>
             登録する
           </Button>
 
-          <Button variant="text" size="small" startIcon={<MdAdd size={20} />} disabled>
+          <Button size="medium" variant="text" endIcon={<MdEdit size={16} />} disabled>
             登録する
           </Button>
 
-          <Button variant="text" size="small" startIcon={<MdAdd size={20} />} loadingPosition="start" loading>
-            登録する
-          </Button>
-        </div>
-
-        <div className="flex flex-col gap-4">
-          <Button variant="text" size="small" endIcon={<MdEdit size={20} />}>
-            登録する
-          </Button>
-
-          <Button variant="text" size="small" endIcon={<MdEdit size={20} />} disabled>
-            登録する
-          </Button>
-
-          <Button variant="text" size="small" endIcon={<MdEdit size={20} />} loadingPosition="end" loading>
+          <Button size="medium" variant="text" endIcon={<MdEdit size={16} />} loadingPosition="end" loading>
             登録する
           </Button>
         </div>

--- a/packages/for-ui/src/button/Button.stories.tsx
+++ b/packages/for-ui/src/button/Button.stories.tsx
@@ -92,29 +92,29 @@ export const Filled = (): JSX.Element => (
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button size="medium" variant="contained" startIcon={<MdAdd size={16} />}>
+          <Button size="medium" variant="contained" startIcon={<MdAdd size={20} />}>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" startIcon={<MdAdd size={16} />} disabled>
+          <Button size="medium" variant="contained" startIcon={<MdAdd size={20} />} disabled>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" startIcon={<MdAdd size={16} />} loadingPosition="start" loading>
+          <Button size="medium" variant="contained" startIcon={<MdAdd size={20} />} loadingPosition="start" loading>
             登録する
           </Button>
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button size="medium" variant="contained" endIcon={<MdEdit size={16} />}>
+          <Button size="medium" variant="contained" endIcon={<MdEdit size={20} />}>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" endIcon={<MdEdit size={16} />} disabled>
+          <Button size="medium" variant="contained" endIcon={<MdEdit size={20} />} disabled>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" endIcon={<MdEdit size={16} />} loadingPosition="end" loading>
+          <Button size="medium" variant="contained" endIcon={<MdEdit size={20} />} loadingPosition="end" loading>
             登録する
           </Button>
         </div>
@@ -194,29 +194,29 @@ export const Contained = (): JSX.Element => (
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button size="medium" variant="contained" startIcon={<MdAdd size={16} />}>
+          <Button size="medium" variant="contained" startIcon={<MdAdd size={20} />}>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" startIcon={<MdAdd size={16} />} disabled>
+          <Button size="medium" variant="contained" startIcon={<MdAdd size={20} />} disabled>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" startIcon={<MdAdd size={16} />} loadingPosition="start" loading>
+          <Button size="medium" variant="contained" startIcon={<MdAdd size={20} />} loadingPosition="start" loading>
             登録する
           </Button>
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button size="medium" variant="contained" endIcon={<MdEdit size={16} />}>
+          <Button size="medium" variant="contained" endIcon={<MdEdit size={20} />}>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" endIcon={<MdEdit size={16} />} disabled>
+          <Button size="medium" variant="contained" endIcon={<MdEdit size={20} />} disabled>
             登録する
           </Button>
 
-          <Button size="medium" variant="contained" endIcon={<MdEdit size={16} />} loadingPosition="end" loading>
+          <Button size="medium" variant="contained" endIcon={<MdEdit size={20} />} loadingPosition="end" loading>
             登録する
           </Button>
         </div>
@@ -296,29 +296,29 @@ export const Outlined = (): JSX.Element => (
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button size="medium" variant="outlined" startIcon={<MdAdd size={16} />}>
+          <Button size="medium" variant="outlined" startIcon={<MdAdd size={20} />}>
             登録する
           </Button>
 
-          <Button size="medium" variant="outlined" startIcon={<MdAdd size={16} />} disabled>
+          <Button size="medium" variant="outlined" startIcon={<MdAdd size={20} />} disabled>
             登録する
           </Button>
 
-          <Button size="medium" variant="outlined" startIcon={<MdAdd size={16} />} loadingPosition="start" loading>
+          <Button size="medium" variant="outlined" startIcon={<MdAdd size={20} />} loadingPosition="start" loading>
             登録する
           </Button>
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button size="medium" variant="outlined" endIcon={<MdEdit size={16} />}>
+          <Button size="medium" variant="outlined" endIcon={<MdEdit size={20} />}>
             登録する
           </Button>
 
-          <Button size="medium" variant="outlined" endIcon={<MdEdit size={16} />} disabled>
+          <Button size="medium" variant="outlined" endIcon={<MdEdit size={20} />} disabled>
             登録する
           </Button>
 
-          <Button size="medium" variant="outlined" endIcon={<MdEdit size={16} />} loadingPosition="end" loading>
+          <Button size="medium" variant="outlined" endIcon={<MdEdit size={20} />} loadingPosition="end" loading>
             登録する
           </Button>
         </div>
@@ -398,29 +398,79 @@ export const _Text = (): JSX.Element => (
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button size="medium" variant="text" startIcon={<MdAdd size={16} />}>
+          <Button size="medium" variant="text" startIcon={<MdAdd size={20} />}>
             登録する
           </Button>
 
-          <Button size="medium" variant="text" startIcon={<MdAdd size={16} />} disabled>
+          <Button size="medium" variant="text" startIcon={<MdAdd size={20} />} disabled>
             登録する
           </Button>
 
-          <Button size="medium" variant="text" startIcon={<MdAdd size={16} />} loadingPosition="start" loading>
+          <Button size="medium" variant="text" startIcon={<MdAdd size={20} />} loadingPosition="start" loading>
             登録する
           </Button>
         </div>
 
         <div className="flex flex-col gap-4">
-          <Button size="medium" variant="text" endIcon={<MdEdit size={16} />}>
+          <Button size="medium" variant="text" endIcon={<MdEdit size={20} />}>
             登録する
           </Button>
 
-          <Button size="medium" variant="text" endIcon={<MdEdit size={16} />} disabled>
+          <Button size="medium" variant="text" endIcon={<MdEdit size={20} />} disabled>
             登録する
           </Button>
 
-          <Button size="medium" variant="text" endIcon={<MdEdit size={16} />} loadingPosition="end" loading>
+          <Button size="medium" variant="text" endIcon={<MdEdit size={20} />} loadingPosition="end" loading>
+            登録する
+          </Button>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div className="mb-4 border-b">
+        <Text variant="h3">Button/Text/Small</Text>
+      </div>
+
+      <div className="flex flex-row gap-8">
+        <div className="flex flex-col gap-4">
+          <Button variant="text" size="small">
+            登録する
+          </Button>
+
+          <Button variant="text" size="small" disabled>
+            登録する
+          </Button>
+
+          <Button variant="text" size="small" loading>
+            登録する
+          </Button>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <Button variant="text" size="small" startIcon={<MdAdd size={20} />}>
+            登録する
+          </Button>
+
+          <Button variant="text" size="small" startIcon={<MdAdd size={20} />} disabled>
+            登録する
+          </Button>
+
+          <Button variant="text" size="small" startIcon={<MdAdd size={20} />} loadingPosition="start" loading>
+            登録する
+          </Button>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <Button variant="text" size="small" endIcon={<MdEdit size={20} />}>
+            登録する
+          </Button>
+
+          <Button variant="text" size="small" endIcon={<MdEdit size={20} />} disabled>
+            登録する
+          </Button>
+
+          <Button variant="text" size="small" endIcon={<MdEdit size={20} />} loadingPosition="end" loading>
             登録する
           </Button>
         </div>

--- a/packages/for-ui/src/button/Button.tsx
+++ b/packages/for-ui/src/button/Button.tsx
@@ -12,12 +12,13 @@ export type ButtonProps = Omit<LoadingButtonProps, 'color' | 'variant' | 'size'>
   color?: 'primary' | 'secondary' | 'default';
 
   // duplicated
-  size?: 'large' | 'medium';
+  size?: 'large' | 'medium' | 'small';
 };
 
 const sizes = {
   large: `px-6 py-2 text-r font-bold`,
   medium: `px-4 py-1 text-s font-bold`,
+  small: `px-2 py-0 text-s hover:bg-transparent`,
 };
 
 const defaultStyles = {

--- a/packages/for-ui/src/button/Button.tsx
+++ b/packages/for-ui/src/button/Button.tsx
@@ -2,7 +2,7 @@ import React, { Children, ReactNode } from 'react';
 import LoadingButton, { LoadingButtonProps } from '@mui/lab/LoadingButton';
 import { fsx } from '../system/fsx';
 
-export type ButtonProps = Omit<LoadingButtonProps, 'color' | 'variant'> & {
+export type ButtonProps = Omit<LoadingButtonProps, 'color' | 'variant' | 'size'> & {
   className?: string;
 
   // NOTE: duplicated "contained"
@@ -10,12 +10,14 @@ export type ButtonProps = Omit<LoadingButtonProps, 'color' | 'variant'> & {
 
   // duplicated
   color?: 'primary' | 'secondary' | 'default';
+
+  // duplicated
+  size?: 'large' | 'medium';
 };
 
 const sizes = {
-  large: `px-6 py-2 text-r`,
-  medium: `px-4 py-1 text-s`,
-  small: `px-2 py-0 text-s hover:bg-transparent`,
+  large: `px-6 py-2 text-r font-bold`,
+  medium: `px-4 py-1 text-s font-bold`,
 };
 
 const defaultStyles = {

--- a/packages/for-ui/src/drawer/Drawer.tsx
+++ b/packages/for-ui/src/drawer/Drawer.tsx
@@ -93,7 +93,7 @@ export const Drawer: React.FC<Props> = ({
       {...rest}
     >
       <div className="flex items-center">
-        <Button variant="text" size="small" startIcon={<MdClose size={16} />} onClick={handleClose}>
+        <Button variant="text" size="medium" startIcon={<MdClose size={16} />} onClick={handleClose}>
           閉じる
         </Button>
 


### PR DESCRIPTION
## チケット

- #866 

## 実装内容

- ボタンサイズをlargeとmediumのみに変更
- ストーリーブックからsmall定義されたものをmediumに変更
- ボタンのフォントをboldに変更

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|   ![screencapture-localhost-6006-2022-12-04-11_54_29](https://user-images.githubusercontent.com/67810971/205472073-50ad4a71-38dc-4301-8621-cf9a181d8f14.png) |    ![screencapture-localhost-6006-2022-12-04-11_56_11](https://user-images.githubusercontent.com/67810971/205472075-889d1ce1-e01a-415d-98ab-66e7f6e88843.png) |

## 相談内容(あれば)

特になし
