### PR TITLE
fix(Radio): テキストのサイズダウンに伴うスタイル修正

### DIFF
--- a/.changeset/friendly-clocks-shout.md
+++ b/.changeset/friendly-clocks-shout.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": minor
+---
+
+fix(Radio): テキストのサイズダウンに伴うスタイル修正

--- a/packages/for-ui/src/radio/Radio.tsx
+++ b/packages/for-ui/src/radio/Radio.tsx
@@ -13,7 +13,7 @@ const Indicator: FC<{ checked: boolean; disabled: boolean }> = ({ checked, disab
   <span
     className={fsx([
       'bg-shade-white-default h-4 w-4 rounded-full transition-[border-width] duration-100',
-      checked ? 'border-[5px]' : 'group-hover:border-secondary-dark-default border-2',
+      checked ? 'border-6' : 'group-hover:border-3 group-hover:border-secondary-dark-default border-2',
       disabled
         ? 'border-shade-medium-disabled'
         : checked
@@ -49,7 +49,7 @@ export const Radio: FC<RadioProps> = forwardRef(({ label, value, disabled, ...re
           ref={ref}
           classes={{
             root: fsx(['group m-0 flex gap-1']),
-            label: fsx(['text-s text-shade-dark-default font-sans']),
+            label: fsx(['text-r text-shade-dark-default font-sans']),
             disabled: fsx(['text-shade-dark-disabled']),
           }}
         />

--- a/packages/for-ui/src/radio/Radio.tsx
+++ b/packages/for-ui/src/radio/Radio.tsx
@@ -13,7 +13,7 @@ const Indicator: FC<{ checked: boolean; disabled: boolean }> = ({ checked, disab
   <span
     className={fsx([
       'bg-shade-white-default h-4 w-4 rounded-full transition-[border-width] duration-100',
-      checked ? 'border-6' : 'group-hover:border-3 group-hover:border-secondary-dark-default border-2',
+      checked ? 'border-6' : 'group-hover:border-secondary-dark-default border-2',
       disabled
         ? 'border-shade-medium-disabled'
         : checked
@@ -30,7 +30,7 @@ const _Radio: FC<RadioProps> = memo(({ nopadding, disabled, ref, ...rest }) => (
     checkedIcon={<Indicator checked={true} disabled={!!disabled} />}
     disabled={disabled}
     classes={{
-      root: fsx(['group hover:bg-transparent', nopadding ? 'p-0' : 'p-6']),
+      root: fsx(['group hover:bg-transparent', nopadding ? 'p-0' : 'p-1']),
     }}
     inputRef={ref}
     {...rest}

--- a/packages/for-ui/src/radio/Radio.tsx
+++ b/packages/for-ui/src/radio/Radio.tsx
@@ -12,8 +12,8 @@ export interface RadioProps extends MuiRadioProps {
 const Indicator: FC<{ checked: boolean; disabled: boolean }> = ({ checked, disabled }) => (
   <span
     className={fsx([
-      'bg-shade-white-default h-5 w-5 rounded-full transition-[border-width] duration-100',
-      checked ? 'border-7' : 'group-hover:border-3 group-hover:border-secondary-dark-default border-2',
+      'bg-shade-white-default h-4 w-4 rounded-full transition-[border-width] duration-100',
+      checked ? 'border-[5px]' : 'group-hover:border-secondary-dark-default border-2',
       disabled
         ? 'border-shade-medium-disabled'
         : checked
@@ -30,7 +30,7 @@ const _Radio: FC<RadioProps> = memo(({ nopadding, disabled, ref, ...rest }) => (
     checkedIcon={<Indicator checked={true} disabled={!!disabled} />}
     disabled={disabled}
     classes={{
-      root: fsx(['group hover:bg-transparent', nopadding ? 'p-0' : 'p-1']),
+      root: fsx(['group hover:bg-transparent', nopadding ? 'p-0' : 'p-6']),
     }}
     inputRef={ref}
     {...rest}
@@ -48,7 +48,7 @@ export const Radio: FC<RadioProps> = forwardRef(({ label, value, disabled, ...re
           control={<_Radio value={value} disabled={disabled} ref={ref} {...rest} />}
           ref={ref}
           classes={{
-            root: fsx(['group m-0 flex gap-2']),
+            root: fsx(['group m-0 flex gap-1']),
             label: fsx(['text-s text-shade-dark-default font-sans']),
             disabled: fsx(['text-shade-dark-disabled']),
           }}

--- a/packages/for-ui/tailwind.config.base.js
+++ b/packages/for-ui/tailwind.config.base.js
@@ -437,6 +437,7 @@ module.exports = {
       },
       borderWidth: {
         3: '3px',
+        6: '6px',
         7: '7px',
       },
       spacing: {


### PR DESCRIPTION
## チケット

- #905 

## 実装内容

- labelとのgapを8pxから4pxに
- paddingありのRadioを縦横24pxに
- indicator部分のサイズを16pxに
- hover時はborderの太さを変えず色だけ変える
- selectedなときはborderの太さを5pxに

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|    <img width="1202" alt="スクリーンショット 2022-12-06 7 43 33" src="https://user-images.githubusercontent.com/67810971/205758810-66719380-fdbe-466f-b828-4d1bb33590fa.png">    |   <img width="1208" alt="スクリーンショット 2022-12-06 7 43 20" src="https://user-images.githubusercontent.com/67810971/205758807-14b65e25-2efd-45fc-8fda-b54c31a0f16b.png">     |



## 相談内容(あれば)

- 特にありません
