### PR TITLE
fix(Table): Row Componentが `className` propsを受け取れるように修正

### DIFF
--- a/.changeset/wild-plants-applaud.md
+++ b/.changeset/wild-plants-applaud.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(Table): Row Componentが `className` propsを受け取れるように修正

--- a/packages/for-ui/src/table/Table.tsx
+++ b/packages/for-ui/src/table/Table.tsx
@@ -215,14 +215,16 @@ export type RowProps<T extends RowData> = {
   row: RowType<T>;
   selectable: boolean;
   onClick: (e: MouseEvent<HTMLTableRowElement>, row: RowType<T>) => void;
+  className?: string;
 };
 
-export const Row = <T extends RowData>({ row, selectable, onClick }: RowProps<T>) => (
+export const Row = <T extends RowData>({ row, selectable, onClick, className }: RowProps<T>) => (
   <tr
     key={row.id}
     className={fsx([
       'border-shade-light-default border-b transition duration-300 ease-in-out',
       selectable && 'hover:bg-shade-light-default cursor-pointer',
+      className,
     ])}
     onClick={(e) => onClick(e, row)}
   >


### PR DESCRIPTION
## チケット

- #910 

## 実装内容

- Row Componentが `className` を受け取れるように修正 (fsxの対応後入れるのを忘れていた)

## スクリーンショット

差分がないため割愛

## 相談内容(あれば)

-
