### PR TITLE
fix(Switch): テキストのサイズダウンに伴うスタイル修正 

### DIFF
--- a/.changeset/quick-mangos-impress.md
+++ b/.changeset/quick-mangos-impress.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": minor
+---
+
+fix(Switch): テキストのサイズダウンに伴うスタイル修正 

--- a/packages/for-ui/src/switch/Switch.tsx
+++ b/packages/for-ui/src/switch/Switch.tsx
@@ -10,6 +10,10 @@ export type SwitchProps = Omit<FormControlLabelProps, 'control'> & {
 export const Switch: React.FC<SwitchProps> = ({ value, checked, disabled, ...rest }) => {
   return (
     <FormControlLabel
+      classes={{
+        root: fsx(['m-0 flex gap-1']),
+        label: fsx(['text-r text-shade-dark-default font-sans']),
+      }}
       control={
         <MuiSwitch
           value={value}

--- a/packages/for-ui/src/switch/Switch.tsx
+++ b/packages/for-ui/src/switch/Switch.tsx
@@ -16,8 +16,9 @@ export const Switch: React.FC<SwitchProps> = ({ value, checked, disabled, ...res
           value={value}
           checked={checked}
           disabled={disabled}
+          // toggleの可動域を狭めるために、trackのサイズを変更する
           classes={{
-            root: fsx(['my-2 mr-2 h-6 w-11 p-0']),
+            root: fsx(['my-2 mr-2 h-5 w-8 p-0.5']),
             track: fsx([
               'bg-primary-dark-default block h-full w-full rounded-xl opacity-100',
               checked && 'bg-secondary-dark-default opacity-100',
@@ -25,8 +26,10 @@ export const Switch: React.FC<SwitchProps> = ({ value, checked, disabled, ...res
               checked && disabled && 'bg-secondary-dark-disabled opacity-100',
             ]),
             thumb: fsx([
-              'bg-shade-white-default absolute top-1 left-1 h-4 w-4 rounded-2xl transition-all duration-200 ease-in',
+              'bg-shade-white-default absolute top-1 left-1 h-3 w-3 rounded-2xl transition-all duration-200 ease-in-out',
+              checked && 'transform -translate-x-2 ease-in-out',
             ]),
+            input: fsx(['w-8 h-5']),
           }}
         />
       }

--- a/packages/for-ui/src/switch/Switch.tsx
+++ b/packages/for-ui/src/switch/Switch.tsx
@@ -5,7 +5,6 @@ import { fsx } from '../system/fsx';
 
 export type SwitchProps = Omit<FormControlLabelProps, 'control'> & {
   value?: unknown;
-  disable?: boolean;
 };
 
 export const Switch: React.FC<SwitchProps> = ({ value, checked, disabled, ...rest }) => {
@@ -18,18 +17,16 @@ export const Switch: React.FC<SwitchProps> = ({ value, checked, disabled, ...res
           disabled={disabled}
           // toggleの可動域を狭めるために、trackのサイズを変更する
           classes={{
-            root: fsx(['my-2 mr-2 h-5 w-8 p-0.5']),
+            root: fsx('p-0 flex m-0 w-auto h-auto'),
             track: fsx([
-              'bg-primary-dark-default block h-full w-full rounded-xl opacity-100',
+              'bg-primary-dark-default block h-full w-full rounded-xl opacity-100 h-5 w-8',
               checked && 'bg-secondary-dark-default opacity-100',
               disabled && 'bg-primary-dark-disabled opacity-100',
               checked && disabled && 'bg-secondary-dark-disabled opacity-100',
             ]),
-            thumb: fsx([
-              'bg-shade-white-default absolute top-1 left-1 h-3 w-3 rounded-2xl transition-all duration-200 ease-in-out',
-              checked && 'transform -translate-x-2 ease-in-out',
-            ]),
-            input: fsx(['w-8 h-5']),
+            thumb: fsx(['bg-shade-white-default h-4 w-4 rounded-2xl shadow-none']),
+            switchBase: fsx(['m-0.5 p-0 transition-all duration-100 ease-in-out']),
+            checked: fsx(['transform-none pl-3']),
           }}
         />
       }


### PR DESCRIPTION
## チケット

- #870 

## 実装内容

- サイズの調整
toggleの大きさを4remに
p-0.5 にする
横幅は32pxになるように

## スクリーンショット



| 変更前 | 変更後 |
| ------ | ------ |
|   <img width="628" alt="スクリーンショット 2022-12-09 6 57 29" src="https://user-images.githubusercontent.com/67810971/206576285-f9dcbd10-09d3-4a3a-bdfa-047f36c0935f.png">     |    <img width="594" alt="スクリーンショット 2022-12-09 6 56 35" src="https://user-images.githubusercontent.com/67810971/206576310-426033d4-fe78-4e36-951d-84365c5e6fcf.png">    |

## 相談内容(あれば)

- toggleのサイズや可動域をかなり無理やり調整した感があります...脱muiした方が管理しやすいかもです👀
