### PR TITLE
fix: `className` prop が抜けているコンポーネントに `className` propを追加

### DIFF
--- a/.changeset/eleven-onions-argue.md
+++ b/.changeset/eleven-onions-argue.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix: `className` prop が抜けているコンポーネントに追加

--- a/packages/for-ui/src/checkbox/Checkbox.tsx
+++ b/packages/for-ui/src/checkbox/Checkbox.tsx
@@ -8,26 +8,27 @@ export type CheckboxProps = MuiCheckboxProps & {
   nopadding?: boolean;
   // Checbox SVG Font Size
   iconsize?: number | string;
+  className?: string;
 };
 
-const _Checkbox = ({ nopadding = false, iconsize = 28, ...rest }: CheckboxProps) => (
+const _Checkbox = ({ nopadding = false, iconsize = 28, className, ...rest }: CheckboxProps) => (
   <MuiCheckbox
     classes={{
-      root: fsx(['text-shade-medium-default', nopadding ? 'p-0' : 'p-1']),
-      checked: fsx(['text-secondary-dark-default']),
-      disabled: fsx(['text-shade-dark-disabled']),
+      root: fsx('text-shade-medium-default', className, nopadding ? 'p-0' : 'p-1'),
+      checked: fsx('text-secondary-dark-default'),
+      disabled: fsx('text-shade-dark-disabled'),
     }}
     sx={{ '& .MuiSvgIcon-root': { fontSize: iconsize } }}
     {...rest}
   />
 );
 
-export const Checkbox = ({ label, nopadding = false, disabled, ...rest }: CheckboxProps) => {
+export const Checkbox = ({ label, nopadding = false, disabled, className, ...rest }: CheckboxProps) => {
   return (
     <>
       {label ? (
         <FormControlLabel
-          sx={{ margin: '0px' }}
+          className={fsx(`m-0`, className)}
           control={<_Checkbox nopadding={nopadding} {...rest} />}
           label={
             <Text size="s" className={fsx(`text-shade-dark-default ml-2`, disabled && `text-shade-dark-disabled`)}>
@@ -36,7 +37,7 @@ export const Checkbox = ({ label, nopadding = false, disabled, ...rest }: Checkb
           }
         />
       ) : (
-        <_Checkbox nopadding={nopadding} {...rest} />
+        <_Checkbox nopadding={nopadding} className={className} {...rest} />
       )}
     </>
   );

--- a/packages/for-ui/src/chip/Chip.tsx
+++ b/packages/for-ui/src/chip/Chip.tsx
@@ -5,8 +5,8 @@ import { fsx } from '../system/fsx';
 type ChipColorType = 'default' | 'negative' | 'white';
 
 export type ChipProps = Omit<MuiChipProps, 'color' | 'icon' | 'deleteIcon' | 'size'> & {
-  // twin?: TwStyle[]
   color?: ChipColorType;
+  className?: string;
 } & (
     | {
         leadingIcon: MuiChipProps['icon'];
@@ -63,6 +63,7 @@ export const Chip: FC<ChipProps> = ({
   trailingIcon,
   clickable,
   onDelete,
+  className,
   ...props
 }) => {
   return (
@@ -77,6 +78,7 @@ export const Chip: FC<ChipProps> = ({
           (trailingIcon || onDelete) && 'pr-2',
           !onDelete && trailingIcon ? 'flex-row-reverse' : '',
           rootStyles(!!(clickable || onDelete))[color],
+          className,
         ]),
         label: fsx(['text-s px-0 font-sans'], labelStyles(!!(clickable || onDelete))[color]),
         icon: fsx(['m-0', iconStyles(!!(clickable || onDelete))[color]]),

--- a/packages/for-ui/src/drawer/Drawer.tsx
+++ b/packages/for-ui/src/drawer/Drawer.tsx
@@ -13,6 +13,7 @@ type Props = MuiDrawerProps & {
   minWidth?: number;
   minHeight?: number;
   onClose?: () => void;
+  className?: string;
 };
 
 const _minWidth = 240;
@@ -31,6 +32,7 @@ export const Drawer: React.FC<Props> = ({
   minWidth = _minWidth,
   children,
   onClose,
+  className,
   ...rest
 }) => {
   const ref = useRef(null);
@@ -80,8 +82,8 @@ export const Drawer: React.FC<Props> = ({
       open={open}
       anchor={anchor}
       classes={{
-        root: fsx(['shadow-drawer z-modal']),
-        paper: fsx(['p-6 [&.MuiBackdrop-root]:bg-transparent']),
+        root: fsx('shadow-drawer z-modal', className),
+        paper: fsx('p-6 [&.MuiBackdrop-root]:bg-transparent'),
       }}
       PaperProps={{
         sx: {

--- a/packages/for-ui/src/dropzone/Dropzone.tsx
+++ b/packages/for-ui/src/dropzone/Dropzone.tsx
@@ -11,6 +11,7 @@ export type DropzoneProps = {
   multiple?: boolean;
   onDrop: (acceptedFiles: File[]) => void;
   onRemove: (file: File) => (e: React.MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
 };
 
 export const Dropzone: React.FC<DropzoneProps> = ({
@@ -19,6 +20,7 @@ export const Dropzone: React.FC<DropzoneProps> = ({
   onRemove,
   message = 'ここにファイルをドロップしてアップロード',
   multiple = false,
+  className,
 }) => {
   const { getRootProps, getInputProps } = useDropzone({ onDrop, multiple });
 
@@ -28,6 +30,7 @@ export const Dropzone: React.FC<DropzoneProps> = ({
       className={fsx([
         'flex w-auto cursor-pointer flex-col flex-wrap justify-center py-3 px-5',
         'border-shade-medium-default rounded border border-dashed',
+        className,
       ])}
     >
       <input {...getInputProps()} />

--- a/packages/for-ui/src/menu/Menu.tsx
+++ b/packages/for-ui/src/menu/Menu.tsx
@@ -7,6 +7,7 @@ import { usePopupState } from 'material-ui-popup-state/hooks';
 export type MenuProps = Omit<MuiMenuProps, 'open'> & {
   TriggerComponent: React.ReactNode;
   nopadding?: boolean;
+  className?: string;
 };
 
 export const Menu = forwardRef<HTMLDivElement, MenuProps>(
@@ -23,6 +24,7 @@ export const Menu = forwardRef<HTMLDivElement, MenuProps>(
       children,
       TriggerComponent,
       nopadding = false,
+      className,
       ...rest
     },
     ref
@@ -49,7 +51,7 @@ export const Menu = forwardRef<HTMLDivElement, MenuProps>(
           anchorOrigin={anchorOrigin}
           transformOrigin={transformOrigin}
           classes={{
-            root: fsx(['translate-y-2']),
+            root: fsx('translate-y-2', className),
             paper: fsx(['z-modal shadow-menu  min-w-min rounded-[4px]', nopadding ? 'p-0' : 'p-1']),
             list: fsx(['divide-shade-light-default grid grid-cols-1 divide-y py-0']),
             ...rest.classes,

--- a/packages/for-ui/src/modal/Modal.tsx
+++ b/packages/for-ui/src/modal/Modal.tsx
@@ -13,6 +13,8 @@ export type ModalProps = Omit<MuiModalProps, 'children'> & {
 
   /** Handler that is called when the 'cancel' button of a dismissable Dialog is clicked. */
   onClose?(event: React.MouseEvent | React.KeyboardEvent): void;
+
+  className?: string;
 };
 
 const Backdrop: React.FC<BackdropProps> = ({ open, children, onClick }) => {
@@ -29,14 +31,19 @@ const Backdrop: React.FC<BackdropProps> = ({ open, children, onClick }) => {
   );
 };
 
-export const Modal: React.FC<ModalProps> = forwardRef(({ open, onClose, children, ...props }, ref) => {
+export const Modal: React.FC<ModalProps> = forwardRef(({ open, onClose, children, className, ...props }, ref) => {
   return (
     <MuiModal
       ref={ref}
       open={open}
       onClose={onClose}
-      BackdropComponent={Backdrop}
-      BackdropProps={{ onClick: onClose }}
+      slots={{
+        backdrop: Backdrop,
+      }}
+      slotProps={{
+        backdrop: { onClick: onClose },
+      }}
+      className={className}
       {...props}
     >
       <div className="flex min-h-screen justify-center focus-visible:outline-none focus-visible:ring-0">

--- a/packages/for-ui/src/radio/Radio.tsx
+++ b/packages/for-ui/src/radio/Radio.tsx
@@ -38,25 +38,27 @@ const _Radio: FC<RadioProps> = memo(({ nopadding, disabled, ref, ...rest }) => (
   />
 ));
 
-export const Radio: FC<RadioProps> = forwardRef<HTMLButtonElement, RadioProps>(({ label, value, disabled, className, ...rest }, ref) => {
-  return (
-    <Fragment>
-      {label ? (
-        <FormControlLabel
-          disabled={disabled}
-          value={value}
-          label={label}
-          control={<_Radio value={value} disabled={disabled} ref={ref} {...rest} />}
-          ref={ref}
-          classes={{
-            root: fsx('group m-0 flex gap-2', className),
-            label: fsx('text-s text-shade-dark-default font-sans'),
-            disabled: fsx('text-shade-dark-disabled'),
-          }}
-        />
-      ) : (
-        <_Radio value={value} disabled={disabled} ref={ref} {...rest} />
-      )}
-    </Fragment>
-  );
-});
+export const Radio: FC<RadioProps> = forwardRef<HTMLButtonElement, RadioProps>(
+  ({ label, value, disabled, className, ...rest }, ref) => {
+    return (
+      <Fragment>
+        {label ? (
+          <FormControlLabel
+            disabled={disabled}
+            value={value}
+            label={label}
+            control={<_Radio value={value} disabled={disabled} ref={ref} {...rest} />}
+            ref={ref}
+            classes={{
+              root: fsx('group m-0 flex gap-2', className),
+              label: fsx('text-s text-shade-dark-default font-sans'),
+              disabled: fsx('text-shade-dark-disabled'),
+            }}
+          />
+        ) : (
+          <_Radio value={value} disabled={disabled} ref={ref} {...rest} />
+        )}
+      </Fragment>
+    );
+  }
+);

--- a/packages/for-ui/src/radio/Radio.tsx
+++ b/packages/for-ui/src/radio/Radio.tsx
@@ -7,6 +7,7 @@ export interface RadioProps extends MuiRadioProps {
   label?: string;
   error?: string;
   nopadding?: boolean;
+  className?: string;
 }
 
 const Indicator: FC<{ checked: boolean; disabled: boolean }> = ({ checked, disabled }) => (
@@ -37,7 +38,7 @@ const _Radio: FC<RadioProps> = memo(({ nopadding, disabled, ref, ...rest }) => (
   />
 ));
 
-export const Radio: FC<RadioProps> = forwardRef(({ label, value, disabled, ...rest }, ref) => {
+export const Radio: FC<RadioProps> = forwardRef<HTMLButtonElement, RadioProps>(({ label, value, disabled, className, ...rest }, ref) => {
   return (
     <Fragment>
       {label ? (
@@ -48,9 +49,9 @@ export const Radio: FC<RadioProps> = forwardRef(({ label, value, disabled, ...re
           control={<_Radio value={value} disabled={disabled} ref={ref} {...rest} />}
           ref={ref}
           classes={{
-            root: fsx(['group m-0 flex gap-2']),
-            label: fsx(['text-s text-shade-dark-default font-sans']),
-            disabled: fsx(['text-shade-dark-disabled']),
+            root: fsx('group m-0 flex gap-2', className),
+            label: fsx('text-s text-shade-dark-default font-sans'),
+            disabled: fsx('text-shade-dark-disabled'),
           }}
         />
       ) : (

--- a/packages/for-ui/src/select/Select.tsx
+++ b/packages/for-ui/src/select/Select.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, forwardRef } from 'react';
 import { UseAutocompleteProps } from '@mui/material';
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
 import MuiPaper, { PaperProps } from '@mui/material/Paper';
@@ -27,24 +27,25 @@ export type AutocompleteProps = UseAutocompleteProps<SelectOption, boolean, bool
   fullWidth?: boolean;
   loadingText?: React.ReactNode;
   disabled?: boolean;
+  className?: string;
 };
 
-export const Select: FC<AutocompleteProps> = ({
+export const Select: FC<AutocompleteProps> = forwardRef<HTMLInputElement, AutocompleteProps>(({
   name,
   options = [],
   label,
   required = false,
-  // twin,
-  // inputTwin,
+  className,
   placeholder,
   multiple,
   freeSolo,
   onChange,
   disabled = false,
   ...rest
-}) => {
+}, ref) => {
   return (
     <Autocomplete
+      ref={ref}
       disablePortal
       disableCloseOnSelect={multiple}
       disableClearable
@@ -115,7 +116,7 @@ export const Select: FC<AutocompleteProps> = ({
         );
       }}
       classes={{
-        root: fsx(['bg-shade-white-default', '']),
+        root: fsx(['bg-shade-white-default', className]),
         paper: fsx(['min-w-min translate-y-4 rounded-2xl py-2']),
         inputRoot: fsx(['group bg-shade-white-default text-shade-light-default p-0 antialiased']),
         input: fsx([
@@ -143,4 +144,4 @@ export const Select: FC<AutocompleteProps> = ({
       {...rest}
     />
   );
-};
+})

--- a/packages/for-ui/src/select/Select.tsx
+++ b/packages/for-ui/src/select/Select.tsx
@@ -30,118 +30,123 @@ export type AutocompleteProps = UseAutocompleteProps<SelectOption, boolean, bool
   className?: string;
 };
 
-export const Select: FC<AutocompleteProps> = forwardRef<HTMLInputElement, AutocompleteProps>(({
-  name,
-  options = [],
-  label,
-  required = false,
-  className,
-  placeholder,
-  multiple,
-  freeSolo,
-  onChange,
-  disabled = false,
-  ...rest
-}, ref) => {
-  return (
-    <Autocomplete
-      ref={ref}
-      disablePortal
-      disableCloseOnSelect={multiple}
-      disableClearable
-      autoHighlight
-      clearOnBlur
-      disabled={disabled}
-      includeInputInList
-      handleHomeEndKeys
-      multiple={multiple}
-      freeSolo={freeSolo}
-      options={options}
-      onChange={onChange}
-      PaperComponent={Paper}
-      isOptionEqualToValue={(option, v) => option.inputValue === v.inputValue}
-      noOptionsText="データが見つかりません"
-      popupIcon={<MdExpandMore size={24} />}
-      filterOptions={(options, params) => {
-        const filtered = filter(options, params);
-        const { inputValue } = params;
-        // Suggest the creation of a new value
-        const isExisting = options.some((option) => {
-          return typeof option === 'string' ? inputValue === option : inputValue === option.inputValue;
-        });
-
-        if (!freeSolo && !isExisting) {
-          return filtered;
-        }
-
-        if (inputValue !== '' && !isExisting) {
-          filtered.push({
-            inputValue,
-            label: inputValue,
+export const Select: FC<AutocompleteProps> = forwardRef<HTMLInputElement, AutocompleteProps>(
+  (
+    {
+      name,
+      options = [],
+      label,
+      required = false,
+      className,
+      placeholder,
+      multiple,
+      freeSolo,
+      onChange,
+      disabled = false,
+      ...rest
+    },
+    ref
+  ) => {
+    return (
+      <Autocomplete
+        ref={ref}
+        disablePortal
+        disableCloseOnSelect={multiple}
+        disableClearable
+        autoHighlight
+        clearOnBlur
+        disabled={disabled}
+        includeInputInList
+        handleHomeEndKeys
+        multiple={multiple}
+        freeSolo={freeSolo}
+        options={options}
+        onChange={onChange}
+        PaperComponent={Paper}
+        isOptionEqualToValue={(option, v) => option.inputValue === v.inputValue}
+        noOptionsText="データが見つかりません"
+        popupIcon={<MdExpandMore size={24} />}
+        filterOptions={(options, params) => {
+          const filtered = filter(options, params);
+          const { inputValue } = params;
+          // Suggest the creation of a new value
+          const isExisting = options.some((option) => {
+            return typeof option === 'string' ? inputValue === option : inputValue === option.inputValue;
           });
-        }
 
-        return filtered;
-      }}
-      getOptionLabel={(option) => {
-        // Value selected with enter, right from the input
-        if (typeof option === 'string') {
-          return option;
-        }
-        // Add "xxx" option created dynamically
-        if (option.label) {
-          return option.label;
-        }
-        // Regular option
-        return option.inputValue;
-      }}
-      renderTags={(value, getTagProps) => {
-        return value.map((option, index) => {
-          const tagProps = getTagProps({ index });
+          if (!freeSolo && !isExisting) {
+            return filtered;
+          }
+
+          if (inputValue !== '' && !isExisting) {
+            filtered.push({
+              inputValue,
+              label: inputValue,
+            });
+          }
+
+          return filtered;
+        }}
+        getOptionLabel={(option) => {
+          // Value selected with enter, right from the input
+          if (typeof option === 'string') {
+            return option;
+          }
+          // Add "xxx" option created dynamically
+          if (option.label) {
+            return option.label;
+          }
+          // Regular option
+          return option.inputValue;
+        }}
+        renderTags={(value, getTagProps) => {
+          return value.map((option, index) => {
+            const tagProps = getTagProps({ index });
+            const label = typeof option === 'string' ? option : option.label;
+            return <Chip {...tagProps} key={tagProps.key} label={label} />;
+          });
+        }}
+        renderOption={(props, option, { selected }) => {
           const label = typeof option === 'string' ? option : option.label;
-          return <Chip {...tagProps} key={tagProps.key} label={label} />;
-        });
-      }}
-      renderOption={(props, option, { selected }) => {
-        const label = typeof option === 'string' ? option : option.label;
-        return (
-          <MenuItem
-            {...props}
-            key={option.inputValue}
-            className={fsx([selected && 'text-primary-dark-default hover:bg-shade-white-hover text-base'])}
-          >
-            {label}
-            {selected && <MdCheck size={20} className="text-primary-medium-default absolute right-4" />}
-          </MenuItem>
-        );
-      }}
-      classes={{
-        root: fsx(['bg-shade-white-default', className]),
-        paper: fsx(['min-w-min translate-y-4 rounded-2xl py-2']),
-        inputRoot: fsx(['group bg-shade-white-default text-shade-light-default p-0 antialiased']),
-        input: fsx([
-          'text-r text-shade-dark-default placeholder:text-shade-light-default h-auto py-2.5 px-3 font-sans placeholder:opacity-100 focus:shadow-none',
-        ]),
-        inputFocused: fsx(['border-primary-medium-active']),
-        focused: fsx(['[&_svg]:!icon-shade-medium-active']),
-        tag: fsx(['bg-shade-light-default [&.MuiChip-deleteIcon]:text-shade-dark-default border-none']),
-        endAdornment: fsx(['[&_svg]:icon-shade-medium-default']),
-      }}
-      renderInput={(params) => {
-        return (
-          <TextField
-            {...params}
-            autoComplete="off"
-            name={name}
-            required={required}
-            label={label}
-            variant="outlined"
-            // inputTwin={inputTwin}
-            placeholder={placeholder}
-          />
-        );
-      }}
-      {...rest}
-    />
-  );
-})
+          return (
+            <MenuItem
+              {...props}
+              key={option.inputValue}
+              className={fsx([selected && 'text-primary-dark-default hover:bg-shade-white-hover text-base'])}
+            >
+              {label}
+              {selected && <MdCheck size={20} className="text-primary-medium-default absolute right-4" />}
+            </MenuItem>
+          );
+        }}
+        classes={{
+          root: fsx(['bg-shade-white-default', className]),
+          paper: fsx(['min-w-min translate-y-4 rounded-2xl py-2']),
+          inputRoot: fsx(['group bg-shade-white-default text-shade-light-default p-0 antialiased']),
+          input: fsx([
+            'text-r text-shade-dark-default placeholder:text-shade-light-default h-auto py-2.5 px-3 font-sans placeholder:opacity-100 focus:shadow-none',
+          ]),
+          inputFocused: fsx(['border-primary-medium-active']),
+          focused: fsx(['[&_svg]:!icon-shade-medium-active']),
+          tag: fsx(['bg-shade-light-default [&.MuiChip-deleteIcon]:text-shade-dark-default border-none']),
+          endAdornment: fsx(['[&_svg]:icon-shade-medium-default']),
+        }}
+        renderInput={(params) => {
+          return (
+            <TextField
+              {...params}
+              autoComplete="off"
+              name={name}
+              required={required}
+              label={label}
+              variant="outlined"
+              // inputTwin={inputTwin}
+              placeholder={placeholder}
+            />
+          );
+        }}
+        {...rest}
+      />
+    );
+  }
+);

--- a/packages/for-ui/src/stepper/Stepper.tsx
+++ b/packages/for-ui/src/stepper/Stepper.tsx
@@ -5,7 +5,7 @@ import { fsx } from '../system/fsx';
 
 export type StepperProps = MuiStepperProps & {
   className?: string;
-}
+};
 
 export const Stepper = forwardRef<HTMLDivElement, StepperProps>(
   ({ activeStep, alternativeLabel, children, className, ...rest }, ref) => {

--- a/packages/for-ui/src/stepper/Stepper.tsx
+++ b/packages/for-ui/src/stepper/Stepper.tsx
@@ -3,10 +3,12 @@ import { StepConnector, stepConnectorClasses } from '@mui/material';
 import MuiStepper, { StepperProps as MuiStepperProps } from '@mui/material/Stepper';
 import { fsx } from '../system/fsx';
 
-export type StepperProps = MuiStepperProps;
+export type StepperProps = MuiStepperProps & {
+  className?: string;
+}
 
 export const Stepper = forwardRef<HTMLDivElement, StepperProps>(
-  ({ activeStep, alternativeLabel, children, ...rest }, ref) => {
+  ({ activeStep, alternativeLabel, children, className, ...rest }, ref) => {
     return (
       <MuiStepper
         ref={ref}
@@ -15,8 +17,8 @@ export const Stepper = forwardRef<HTMLDivElement, StepperProps>(
         connector={
           <StepConnector
             classes={{
-              root: fsx(['right-[calc(50%+1rem)] left-[calc(-50%+1rem)] top-6 px-0']),
-              line: fsx(['border-t-2']),
+              root: fsx('right-[calc(50%+1rem)] left-[calc(-50%+1rem)] top-6 px-0', className),
+              line: fsx('border-t-2'),
             }}
             sx={{
               [`&.${stepConnectorClasses.active}`]: {

--- a/packages/for-ui/src/switch/Switch.tsx
+++ b/packages/for-ui/src/switch/Switch.tsx
@@ -22,10 +22,10 @@ export const Switch: React.FC<SwitchProps> = ({ value, checked, disabled, classN
               'bg-primary-dark-default block h-full w-full rounded-xl opacity-100',
               checked && 'bg-secondary-dark-default opacity-100',
               disabled && 'bg-primary-dark-disabled opacity-100',
-              checked && disabled && 'bg-secondary-dark-disabled opacity-100',
+              checked && disabled && 'bg-secondary-dark-disabled opacity-100'
             ),
             thumb: fsx(
-              'bg-shade-white-default absolute top-1 left-1 h-4 w-4 rounded-2xl transition-all duration-200 ease-in',
+              'bg-shade-white-default absolute top-1 left-1 h-4 w-4 rounded-2xl transition-all duration-200 ease-in'
             ),
           }}
         />

--- a/packages/for-ui/src/switch/Switch.tsx
+++ b/packages/for-ui/src/switch/Switch.tsx
@@ -5,10 +5,10 @@ import { fsx } from '../system/fsx';
 
 export type SwitchProps = Omit<FormControlLabelProps, 'control'> & {
   value?: unknown;
-  disable?: boolean;
+  className?: string;
 };
 
-export const Switch: React.FC<SwitchProps> = ({ value, checked, disabled, ...rest }) => {
+export const Switch: React.FC<SwitchProps> = ({ value, checked, disabled, className, ...rest }) => {
   return (
     <FormControlLabel
       control={
@@ -17,16 +17,16 @@ export const Switch: React.FC<SwitchProps> = ({ value, checked, disabled, ...res
           checked={checked}
           disabled={disabled}
           classes={{
-            root: fsx(['my-2 mr-2 h-6 w-11 p-0']),
-            track: fsx([
+            root: fsx('my-2 mr-2 h-6 w-11 p-0', className),
+            track: fsx(
               'bg-primary-dark-default block h-full w-full rounded-xl opacity-100',
               checked && 'bg-secondary-dark-default opacity-100',
               disabled && 'bg-primary-dark-disabled opacity-100',
               checked && disabled && 'bg-secondary-dark-disabled opacity-100',
-            ]),
-            thumb: fsx([
+            ),
+            thumb: fsx(
               'bg-shade-white-default absolute top-1 left-1 h-4 w-4 rounded-2xl transition-all duration-200 ease-in',
-            ]),
+            ),
           }}
         />
       }

--- a/packages/for-ui/src/tab/Tabs.tsx
+++ b/packages/for-ui/src/tab/Tabs.tsx
@@ -7,6 +7,7 @@ export interface TabsProps extends MuiTabsProps {
   noBorder?: boolean;
   reverse?: boolean;
   color?: 'primary' | 'secondary';
+  className?: string;
 }
 
 const colorStyle = {
@@ -32,14 +33,14 @@ const BorderedTabs: React.FC<TabsProps> = (props) => (
   </Box>
 );
 
-const _Tabs: React.FC<TabsProps> = ({ reverse = false, color = 'secondary', value, onChange, children, ...rest }) => {
+const _Tabs: React.FC<TabsProps> = ({ reverse = false, color = 'secondary', value, onChange, children, className, ...rest }) => {
   return (
     <MuiTabs
       value={value}
       onChange={onChange}
       classes={{
-        root: fsx(['min-h-[auto]']),
-        indicator: fsx([colorStyle[color], reverse && 'top-0']),
+        root: fsx('min-h-[auto]', className),
+        indicator: fsx(colorStyle[color], reverse && 'top-0'),
       }}
       {...rest}
     >

--- a/packages/for-ui/src/tab/Tabs.tsx
+++ b/packages/for-ui/src/tab/Tabs.tsx
@@ -33,7 +33,15 @@ const BorderedTabs: React.FC<TabsProps> = (props) => (
   </Box>
 );
 
-const _Tabs: React.FC<TabsProps> = ({ reverse = false, color = 'secondary', value, onChange, children, className, ...rest }) => {
+const _Tabs: React.FC<TabsProps> = ({
+  reverse = false,
+  color = 'secondary',
+  value,
+  onChange,
+  children,
+  className,
+  ...rest
+}) => {
   return (
     <MuiTabs
       value={value}

--- a/packages/for-ui/src/table/Table.tsx
+++ b/packages/for-ui/src/table/Table.tsx
@@ -43,7 +43,18 @@ export type TableProps<T extends RowData> = Pick<TableOptions<T>, 'data' | 'colu
       }
   );
 
-export const Table = <T extends RowData>({ data, disablePagination, defaultSortColumn, onSelectRow, onSelectRows, onRowClick, rowRenderer, getRowId, columns, className }: TableProps<T>) => {
+export const Table = <T extends RowData>({
+  data,
+  disablePagination,
+  defaultSortColumn,
+  onSelectRow,
+  onSelectRows,
+  onRowClick,
+  rowRenderer,
+  getRowId,
+  columns,
+  className,
+}: TableProps<T>) => {
   // const { data, disablePagination, defaultSortColumn, onSelectRow, onSelectRows, onRowClick, rowRenderer } = props;
   const [sorting, setSorting] = useState<SortingState>(defaultSortColumn ? [defaultSortColumn] : []);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -156,7 +167,12 @@ export const Table = <T extends RowData>({ data, disablePagination, defaultSortC
 
   return (
     <>
-      <table className={fsx('border-shade-light-default w-full border-separate border-spacing-0 rounded-sm border', className)}>
+      <table
+        className={fsx(
+          'border-shade-light-default w-full border-separate border-spacing-0 rounded-sm border',
+          className
+        )}
+      >
         <thead className="bg-shade-light-default table-header-group">
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id} className="table-row align-middle">

--- a/packages/for-ui/src/table/Table.tsx
+++ b/packages/for-ui/src/table/Table.tsx
@@ -29,6 +29,7 @@ export type TableProps<T extends RowData> = Pick<TableOptions<T>, 'data' | 'colu
   onRowClick?: (e: MouseEvent<HTMLTableRowElement>, row: RowType<T>) => void;
   /** The component used to render reach row. By default, Row is used. */
   rowRenderer?: FC<RowProps<T>>;
+  className?: string;
 } & (
     | {
         /** If wanting to use selectable table, specify _onSelectRow_ or _onSelectRows_ exclusively */
@@ -42,8 +43,8 @@ export type TableProps<T extends RowData> = Pick<TableOptions<T>, 'data' | 'colu
       }
   );
 
-export const Table = <T extends RowData>(props: TableProps<T>) => {
-  const { data, disablePagination, defaultSortColumn, onSelectRow, onSelectRows, onRowClick, rowRenderer } = props;
+export const Table = <T extends RowData>({ data, disablePagination, defaultSortColumn, onSelectRow, onSelectRows, onRowClick, rowRenderer, getRowId, columns, className }: TableProps<T>) => {
+  // const { data, disablePagination, defaultSortColumn, onSelectRow, onSelectRows, onRowClick, rowRenderer } = props;
   const [sorting, setSorting] = useState<SortingState>(defaultSortColumn ? [defaultSortColumn] : []);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const prevRowSelection = useRef<RowSelectionState>({});
@@ -77,10 +78,10 @@ export const Table = <T extends RowData>(props: TableProps<T>) => {
 
   const RowComponent: FC<RowProps<T>> = rowRenderer || Row;
 
-  const columns = useMemo(() => {
+  const selectableColumns = useMemo(() => {
     // Not selectable table
     if (!(onSelectRow || onSelectRows)) {
-      return props.columns;
+      return columns;
     }
 
     const selectColumn: ColumnDef<T> = {
@@ -132,17 +133,17 @@ export const Table = <T extends RowData>(props: TableProps<T>) => {
         </TableCell>
       ),
     };
-    return [selectColumn, ...props.columns];
-  }, [props, onSelectRow, onSelectRows, selectRow]);
+    return [selectColumn, ...columns];
+  }, [onSelectRow, onSelectRows, selectRow, columns]);
 
   const table = useReactTable({
     data,
-    columns,
+    columns: selectableColumns,
     state: {
       sorting,
       rowSelection,
     },
-    getRowId: props.getRowId,
+    getRowId,
     onRowSelectionChange,
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
@@ -155,7 +156,7 @@ export const Table = <T extends RowData>(props: TableProps<T>) => {
 
   return (
     <>
-      <table className="border-shade-light-default w-full border-separate border-spacing-0 rounded-sm border">
+      <table className={fsx('border-shade-light-default w-full border-separate border-spacing-0 rounded-sm border', className)}>
         <thead className="bg-shade-light-default table-header-group">
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id} className="table-row align-middle">

--- a/packages/for-ui/tailwind.config.base.js
+++ b/packages/for-ui/tailwind.config.base.js
@@ -416,7 +416,7 @@ module.exports = {
     borderColor: borderColors,
     ringColor: borderColors,
     iconColor: iconColors,
-    fillColor: iconColors,
+    fill: iconColors,
     fontSize: {
       xs: fontSizes.s,
       sm: fontSizes.s,


### PR DESCRIPTION
## チケット

- Close #936 

## 実装内容

- `className` prop が抜けているコンポーネントに `className` propを追加
- `Select` コンポーネントをforwardRefするように修正
- tailwind.config.base.jsの修正
  - `fillColor` → `fill`

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
