### PR TITLE
fix: `xl` のサイズを修正

### DIFF
--- a/.changeset/witty-spiders-knock.md
+++ b/.changeset/witty-spiders-knock.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": minor
+---
+
+fix: `xl` のサイズを修正

--- a/packages/for-ui/tailwind.config.base.js
+++ b/packages/for-ui/tailwind.config.base.js
@@ -334,7 +334,7 @@ const fontSizes = {
     },
   ],
   xl: [
-    '2rem',
+    '1.5rem',
     {
       lineHeight: '2.5rem',
       letterSpacing: '0',


### PR DESCRIPTION
## チケット

- Close #944
 
## 実装内容

- xlの値を修正 (32px -> 24px)

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|    <img width="1003" alt="image" src="https://user-images.githubusercontent.com/8467289/208844493-58b7d72b-0858-474b-90c6-110567f5222e.png">    |   <img width="1006" alt="image" src="https://user-images.githubusercontent.com/8467289/208844428-40dbecf8-21e6-4031-8d38-faa6dec44585.png">     |

## 相談内容(あれば)

-
