### PR TITLE
feat(TextField): `TextField / URL` を実装

### DIFF
--- a/.changeset/plenty-pans-sip.md
+++ b/.changeset/plenty-pans-sip.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+feat(TextField): `TextField / URL` を実装

--- a/example/vite-app/src/components/map/index.tsx
+++ b/example/vite-app/src/components/map/index.tsx
@@ -183,7 +183,6 @@ export const Map = () => {
               <div className="flex items-center p-3">
                 <TextField
                   required
-                  variant="outlined"
                   autoComplete="on"
                   placeholder="3"
                   unitLabel="万円"
@@ -194,7 +193,6 @@ export const Map = () => {
 
                 <TextField
                   required
-                  variant="outlined"
                   autoComplete="on"
                   placeholder="3"
                   unitLabel="万円"

--- a/example/vite-app/src/components/map/index.tsx
+++ b/example/vite-app/src/components/map/index.tsx
@@ -181,23 +181,11 @@ export const Map = () => {
               </div>
 
               <div className="flex items-center p-3">
-                <TextField
-                  required
-                  autoComplete="on"
-                  placeholder="3"
-                  unitLabel="万円"
-                  isPriceFormat
-                />
+                <TextField required autoComplete="on" placeholder="3" unitLabel="万円" isPriceFormat />
 
                 <div className="px-3">~</div>
 
-                <TextField
-                  required
-                  autoComplete="on"
-                  placeholder="3"
-                  unitLabel="万円"
-                  isPriceFormat
-                />
+                <TextField required autoComplete="on" placeholder="3" unitLabel="万円" isPriceFormat />
               </div>
             </div>
           </Menu>

--- a/packages/for-ui/src/select/Select.tsx
+++ b/packages/for-ui/src/select/Select.tsx
@@ -139,7 +139,6 @@ export const Select: FC<AutocompleteProps> = forwardRef<HTMLInputElement, Autoco
               name={name}
               required={required}
               label={label}
-              variant="outlined"
               // inputTwin={inputTwin}
               placeholder={placeholder}
             />

--- a/packages/for-ui/src/textField/TextField.stories.tsx
+++ b/packages/for-ui/src/textField/TextField.stories.tsx
@@ -47,7 +47,6 @@ export const Outlined = (): JSX.Element => {
         <TextField
           required
           fullWidth
-          variant="outlined"
           error={!!errors['email']}
           autoComplete="on"
           type="email"

--- a/packages/for-ui/src/textField/TextField.stories.tsx
+++ b/packages/for-ui/src/textField/TextField.stories.tsx
@@ -17,9 +17,14 @@ const schema = yup.object({
   email: yup.string().required(),
   password: yup.string().required(),
   price: yup.number().min(2).optional(),
+  account: yup.string().optional(),
 });
 
 type FieldValue = yup.InferType<typeof schema>;
+
+export const Playground = {
+  prefix: "",
+}
 
 export const Outlined = (): JSX.Element => {
   const {
@@ -85,6 +90,20 @@ export const Outlined = (): JSX.Element => {
         {errors['price'] && (
           <Text size="s" className="text-negative-medium-default">
             金額は2万円以上を入力してください
+          </Text>
+        )}
+      </div>
+
+      <div>
+        <TextField
+          label="アカウント名"
+          prefix="https://example.com/accounts/"
+          error={!!errors['account']}
+          {...register('account')}
+        />
+        {errors['account'] && (
+          <Text size="s" className="text-negative-medium-default">
+            エラーです
           </Text>
         )}
       </div>

--- a/packages/for-ui/src/textField/TextField.stories.tsx
+++ b/packages/for-ui/src/textField/TextField.stories.tsx
@@ -23,8 +23,8 @@ const schema = yup.object({
 type FieldValue = yup.InferType<typeof schema>;
 
 export const Playground = {
-  prefix: "",
-}
+  prefix: '',
+};
 
 export const Outlined = (): JSX.Element => {
   const {

--- a/packages/for-ui/src/textField/TextField.tsx
+++ b/packages/for-ui/src/textField/TextField.tsx
@@ -1,13 +1,26 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import { ReactNode, FocusEvent, forwardRef, useCallback, useMemo, useState } from 'react';
 import InputAdornment from '@mui/material/InputAdornment';
 import MuiTextField, { TextFieldProps as MuiTextFieldProps } from '@mui/material/TextField';
-import { fsx } from '../system/fsx';
 import { NumericFormat } from 'react-number-format';
+import { fsx } from '../system/fsx';
+import { Text } from '../text'
 
-export type TextFieldProps = Omit<MuiTextFieldProps, 'multiline' | 'rows'> & {
+export type TextFieldProps = Omit<MuiTextFieldProps, 'variant' | 'multiline' | 'rows' | 'margin'> & {
+  /**
+   * 単位を表示する場合に指定してください。
+   */
   unitLabel?: string;
+
+  /**
+   * 3桁区切りの金額表示をする場合に指定してください。入力値はnumberのみ許可されます。
+   */
   isPriceFormat?: boolean;
-  variant?: 'outlined';
+
+  /**
+   * URLの先頭部分など期待する入力値にユーザーが入力しない部分があることを明示的にしたい場合、prefixを指定してください。
+   */
+  prefix?: string;
+
   className?: string;
 };
 
@@ -16,16 +29,16 @@ type NumberFormatCustomProps = {
   name: string;
   className?: string;
   other: {
-    children?: React.ReactNode;
+    children?: ReactNode;
   };
 };
 
-const NumberFormatCustom: React.ForwardRefExoticComponent<NumberFormatCustomProps> = React.forwardRef(
-  ({ onChange, name, ...other }, ref) => {
+const NumberFormatCustom = forwardRef<HTMLInputElement, NumberFormatCustomProps>(
+  ({ onChange, name, className, ...rest }, ref) => {
     return (
       <NumericFormat
-        {...other}
-        className={fsx([other.className, 'text-right'])}
+        {...rest}
+        className={fsx(['text-right', className])}
         getInputRef={ref}
         onValueChange={(values) => {
           onChange({
@@ -41,11 +54,10 @@ const NumberFormatCustom: React.ForwardRefExoticComponent<NumberFormatCustomProp
   }
 );
 
-export const TextField: React.ForwardRefExoticComponent<TextFieldProps> = React.forwardRef(
+export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   (
     {
       label,
-      variant = 'outlined',
       className,
       focused,
       placeholder,
@@ -58,6 +70,7 @@ export const TextField: React.ForwardRefExoticComponent<TextFieldProps> = React.
       error,
       unitLabel = '',
       isPriceFormat = false,
+      prefix = '',
       InputProps,
       onFocus,
       onBlur,
@@ -97,20 +110,16 @@ export const TextField: React.ForwardRefExoticComponent<TextFieldProps> = React.
 
     const [_focused, setFocused] = useState<boolean>(focused || false);
     const handleFocus = useCallback(
-      (e: React.FocusEvent<HTMLInputElement>) => {
+      (e: FocusEvent<HTMLInputElement>) => {
         setFocused(true);
-        if (onFocus) {
-          onFocus(e);
-        }
+        onFocus?.(e);
       },
       [setFocused, onFocus]
     );
     const handleBlur = useCallback(
-      (e: React.FocusEvent<HTMLInputElement>) => {
+      (e: FocusEvent<HTMLInputElement>) => {
         setFocused(false);
-        if (onBlur) {
-          onBlur(e);
-        }
+        onBlur?.(e);
       },
       [setFocused, onBlur]
     );
@@ -134,7 +143,7 @@ export const TextField: React.ForwardRefExoticComponent<TextFieldProps> = React.
             error={error}
             inputRef={validRef}
             required={required}
-            variant={variant}
+            variant="outlined"
             placeholder={placeholder}
             sx={{
               '& .MuiInputBase-input:disabled::placeholder': {
@@ -148,7 +157,9 @@ export const TextField: React.ForwardRefExoticComponent<TextFieldProps> = React.
             }}
             InputProps={{
               classes: {
-                root: fsx(['group bg-shade-white-default text-shade-light-default p-0 antialiased']),
+                root: fsx([
+                  `group bg-shade-white-default text-shade-light-default p-0 antialiased`,
+                ]),
                 disabled: fsx(['bg-shade-white-disabled', 'placeholder:text-shade-light-default']),
                 input: fsx([
                   'text-r text-shade-dark-default placeholder:text-shade-light-default h-auto py-2.5 px-3 font-sans placeholder:opacity-100 focus:shadow-none',
@@ -161,11 +172,17 @@ export const TextField: React.ForwardRefExoticComponent<TextFieldProps> = React.
                     : error
                     ? 'border-negative-medium-default'
                     : _focused
-                    ? 'border-primary-medium-active group-hover:border-primary-dark-default'
+                    ? 'border-2 border-primary-medium-active group-hover:border-primary-dark-default'
                     : 'border-shade-medium-default group-hover:border-primary-dark-default',
                 ]),
                 inputAdornedEnd: fsx(['pr-2']),
               },
+              startAdornment: prefix && (
+                <InputAdornment position="start" classes={{ root: "border-r border-shade-light-default bg-shade-light-default max-h-[fit-content] h-full py-2.5 px-3 m-0" }}>
+                  <Text className="text-shade-dark-default inline-flex">
+                    {prefix}
+                  </Text>
+                </InputAdornment>),
               ...InputProps,
               ..._InputProps,
             }}

--- a/packages/for-ui/src/textField/TextField.tsx
+++ b/packages/for-ui/src/textField/TextField.tsx
@@ -3,7 +3,7 @@ import InputAdornment from '@mui/material/InputAdornment';
 import MuiTextField, { TextFieldProps as MuiTextFieldProps } from '@mui/material/TextField';
 import { NumericFormat } from 'react-number-format';
 import { fsx } from '../system/fsx';
-import { Text } from '../text'
+import { Text } from '../text';
 
 export type TextFieldProps = Omit<MuiTextFieldProps, 'variant' | 'multiline' | 'rows' | 'margin'> & {
   /**
@@ -157,9 +157,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
             }}
             InputProps={{
               classes: {
-                root: fsx([
-                  `group bg-shade-white-default text-shade-light-default p-0 antialiased`,
-                ]),
+                root: fsx([`group bg-shade-white-default text-shade-light-default p-0 antialiased`]),
                 disabled: fsx(['bg-shade-white-disabled', 'placeholder:text-shade-light-default']),
                 input: fsx([
                   'text-r text-shade-dark-default placeholder:text-shade-light-default h-auto py-2.5 px-3 font-sans placeholder:opacity-100 focus:shadow-none',
@@ -178,11 +176,15 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
                 inputAdornedEnd: fsx(['pr-2']),
               },
               startAdornment: prefix && (
-                <InputAdornment position="start" classes={{ root: "border-r border-shade-light-default bg-shade-light-default max-h-[fit-content] h-full py-2.5 px-3 m-0" }}>
-                  <Text className="text-shade-dark-default inline-flex">
-                    {prefix}
-                  </Text>
-                </InputAdornment>),
+                <InputAdornment
+                  position="start"
+                  classes={{
+                    root: 'border-r border-shade-light-default bg-shade-light-default max-h-[fit-content] h-full py-2.5 px-3 m-0',
+                  }}
+                >
+                  <Text className="text-shade-dark-default inline-flex">{prefix}</Text>
+                </InputAdornment>
+              ),
               ...InputProps,
               ..._InputProps,
             }}


### PR DESCRIPTION
## チケット

- Close #948 

## 実装内容

- `TextField / URL`を実装
  - `prefix` propにユーザーが入力しなくても既に入っている値 (例: htttps://github.comなど) を指定することで使えます
- variant と margin propsを削除

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|   <img width="1373" alt="image" src="https://user-images.githubusercontent.com/8467289/209328485-3e8898ad-e6bc-47ec-ae5d-3f8af883084c.png">     |       <img width="1376" alt="image" src="https://user-images.githubusercontent.com/8467289/209328542-9216e1e3-bd57-4eaa-b226-c01038ed6184.png"> |

## 相談内容(あれば)

-
