### PR TITLE
fix(Badge): Badgeコンポーネントのデザイン実装

### DIFF
--- a/.changeset/hip-seas-wash.md
+++ b/.changeset/hip-seas-wash.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(Badge): Badgeコンポーネントのデザイン実装

--- a/.changeset/hip-seas-wash.md
+++ b/.changeset/hip-seas-wash.md
@@ -1,5 +1,5 @@
 ---
-"@4design/for-ui": patch
+"@4design/for-ui": minor
 ---
 
 fix(Badge): Badgeコンポーネントのデザイン実装

--- a/packages/for-ui/src/badge/Badge.stories.tsx
+++ b/packages/for-ui/src/badge/Badge.stories.tsx
@@ -9,35 +9,55 @@ export default {
   component: Badge,
 } as Meta;
 
-const Template: Story = () => (
+const ConstantBadgeTemplate: Story = () => (
   <div className="flex flex-row gap-8">
     <div className="flex flex-col gap-4">
       <Badge label="注意書き" icon={<MdError className="h-4 w-4" />} />
       <Badge label="注意書き" icon={<MdError className="h-4 w-4" />} color="primary" />
       <Badge label="注意書き" icon={<MdError className="h-4 w-4" />} color="native" />
     </div>
-    <div className="flex flex-col gap-4">
-      <Badge label="神田 柚奈" color="white" variant="text" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="white" variant="text" />
-      <Badge label="神田 柚奈" color="gray" variant="text" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="gray" variant="text" />
-      <Badge label="神田 柚奈" color="primary" variant="text" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="primary" variant="text" />
-      <Badge label="神田 柚奈" color="native" variant="text" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="native" variant="text" />
-    </div>
-    <div className="flex flex-col gap-4">
-      <Badge label="神田 柚奈" color="white" variant="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="white" variant="outline" />
-      <Badge label="神田 柚奈" color="gray" variant="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="gray" variant="outline" />
-      <Badge label="神田 柚奈" color="primary" variant="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="primary" variant="outline" />
-      <Badge label="神田 柚奈" color="native" variant="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="native" variant="outline" />
-    </div>
   </div>
 );
 
-export const DefaultBadge = Template.bind({});
+const TextBadgeTemplate: Story = () => {
+  return (
+    <div className="flex flex-row gap-8">
+      <div className="flex flex-col gap-4">
+        <Badge label="神田 柚奈" color="white" variant="text" icon={<MdPersonOutline className="h-4 w-4" />} />
+        <Badge label="神田 柚奈" color="white" variant="text" />
+        <Badge label="神田 柚奈" color="gray" variant="text" icon={<MdPersonOutline className="h-4 w-4" />} />
+        <Badge label="神田 柚奈" color="gray" variant="text" />
+        <Badge label="神田 柚奈" color="primary" variant="text" icon={<MdPersonOutline className="h-4 w-4" />} />
+        <Badge label="神田 柚奈" color="primary" variant="text" />
+        <Badge label="神田 柚奈" color="native" variant="text" icon={<MdPersonOutline className="h-4 w-4" />} />
+        <Badge label="神田 柚奈" color="native" variant="text" />
+      </div>
+    </div>
+  );
+};
+
+const OutlineBadgeTemplate: Story = () => {
+  return (
+    <div className="flex flex-row gap-8">
+      <div className="flex flex-col gap-4">
+        <Badge label="神田 柚奈" color="white" variant="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
+        <Badge label="神田 柚奈" color="white" variant="outline" />
+        <Badge label="神田 柚奈" color="gray" variant="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
+        <Badge label="神田 柚奈" color="gray" variant="outline" />
+        <Badge label="神田 柚奈" color="primary" variant="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
+        <Badge label="神田 柚奈" color="primary" variant="outline" />
+        <Badge label="神田 柚奈" color="native" variant="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
+        <Badge label="神田 柚奈" color="native" variant="outline" />
+      </div>
+    </div>
+  );
+};
+
+export const DefaultBadge = ConstantBadgeTemplate.bind({});
 DefaultBadge.args = {};
+
+export const TextBadge = TextBadgeTemplate.bind({});
+TextBadge.args = {};
+
+export const OutlineBadge = OutlineBadgeTemplate.bind({});
+OutlineBadge.args = {};

--- a/packages/for-ui/src/badge/Badge.stories.tsx
+++ b/packages/for-ui/src/badge/Badge.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
-import { MdMail } from 'react-icons/md';
+import { MdPersonOutline } from 'react-icons/md';
 import { Badge } from './Badge';
 
 export default {
@@ -9,9 +9,33 @@ export default {
 } as Meta;
 
 const Template: Story = () => (
-  <Badge badgeContent={4}>
-    <MdMail size={24} />
-  </Badge>
+  <div className="flex flex-row gap-8">
+    <div className="flex flex-col gap-4">
+      <Badge label="注意書き" />
+      <Badge label="注意書き" color="primary" />
+      <Badge label="注意書き" color="native" />
+    </div>
+    <div className="flex flex-col gap-4">
+      <Badge label="神田 柚奈" color="white" type="text" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="white" type="text" />
+      <Badge label="神田 柚奈" color="gray" type="text" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="gray" type="text" />
+      <Badge label="神田 柚奈" color="primary" type="text" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="primary" type="text" />
+      <Badge label="神田 柚奈" color="native" type="text" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="native" type="text" />
+    </div>
+    <div className="flex flex-col gap-4">
+      <Badge label="神田 柚奈" color="white" type="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="white" type="outline" />
+      <Badge label="神田 柚奈" color="gray" type="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="gray" type="outline" />
+      <Badge label="神田 柚奈" color="primary" type="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="primary" type="outline" />
+      <Badge label="神田 柚奈" color="native" type="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="native" type="outline" />
+    </div>
+  </div>
 );
 
 export const DefaultBadge = Template.bind({});

--- a/packages/for-ui/src/badge/Badge.stories.tsx
+++ b/packages/for-ui/src/badge/Badge.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { MdPersonOutline } from 'react-icons/md';
 import { Badge } from './Badge';
+import { MdError } from 'react-icons/md';
 
 export default {
   title: 'Example / Badge',
@@ -11,29 +12,29 @@ export default {
 const Template: Story = () => (
   <div className="flex flex-row gap-8">
     <div className="flex flex-col gap-4">
-      <Badge label="注意書き" />
-      <Badge label="注意書き" color="primary" />
-      <Badge label="注意書き" color="native" />
+      <Badge label="注意書き" icon={<MdError className="h-4 w-4" />} />
+      <Badge label="注意書き" icon={<MdError className="h-4 w-4" />} color="primary" />
+      <Badge label="注意書き" icon={<MdError className="h-4 w-4" />} color="native" />
     </div>
     <div className="flex flex-col gap-4">
-      <Badge label="神田 柚奈" color="white" type="text" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="white" type="text" />
-      <Badge label="神田 柚奈" color="gray" type="text" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="gray" type="text" />
-      <Badge label="神田 柚奈" color="primary" type="text" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="primary" type="text" />
-      <Badge label="神田 柚奈" color="native" type="text" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="native" type="text" />
+      <Badge label="神田 柚奈" color="white" variant="text" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="white" variant="text" />
+      <Badge label="神田 柚奈" color="gray" variant="text" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="gray" variant="text" />
+      <Badge label="神田 柚奈" color="primary" variant="text" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="primary" variant="text" />
+      <Badge label="神田 柚奈" color="native" variant="text" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="native" variant="text" />
     </div>
     <div className="flex flex-col gap-4">
-      <Badge label="神田 柚奈" color="white" type="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="white" type="outline" />
-      <Badge label="神田 柚奈" color="gray" type="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="gray" type="outline" />
-      <Badge label="神田 柚奈" color="primary" type="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="primary" type="outline" />
-      <Badge label="神田 柚奈" color="native" type="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
-      <Badge label="神田 柚奈" color="native" type="outline" />
+      <Badge label="神田 柚奈" color="white" variant="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="white" variant="outline" />
+      <Badge label="神田 柚奈" color="gray" variant="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="gray" variant="outline" />
+      <Badge label="神田 柚奈" color="primary" variant="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="primary" variant="outline" />
+      <Badge label="神田 柚奈" color="native" variant="outline" icon={<MdPersonOutline className="h-4 w-4" />} />
+      <Badge label="神田 柚奈" color="native" variant="outline" />
     </div>
   </div>
 );

--- a/packages/for-ui/src/badge/Badge.tsx
+++ b/packages/for-ui/src/badge/Badge.tsx
@@ -1,17 +1,16 @@
 import React, { ReactNode } from 'react';
 
-import { MdError } from 'react-icons/md';
 import { fsx } from '../system/fsx';
 
 type Props = {
   color?: 'white' | 'gray' | 'primary' | 'native';
   icon?: ReactNode;
-  type?: 'constant' | 'text' | 'outline';
+  variant?: 'constant' | 'text' | 'outline';
   label: string;
 };
 
-export const Badge: React.FC<Props> = ({ color = 'white', icon, type = 'constant', label }) => {
-  switch (type) {
+export const Badge: React.FC<Props> = ({ color = 'white', icon, variant = 'constant', label }) => {
+  switch (variant) {
     case 'constant':
       return (
         <div
@@ -22,9 +21,7 @@ export const Badge: React.FC<Props> = ({ color = 'white', icon, type = 'constant
             color === 'native' && 'text-[#C00F50]',
           ])}
         >
-          <div className="flex h-6 w-4 flex-row items-start py-1">
-            <MdError className="h-4 w-4" />
-          </div>
+          <div className="flex h-6 w-4 flex-row items-start py-1">{icon}</div>
           <span className="text-r font-bold">{label}</span>
         </div>
       );
@@ -82,7 +79,5 @@ export const Badge: React.FC<Props> = ({ color = 'white', icon, type = 'constant
           <span>{label}</span>
         </div>
       );
-    default:
-      return null;
   }
 };

--- a/packages/for-ui/src/badge/Badge.tsx
+++ b/packages/for-ui/src/badge/Badge.tsx
@@ -1,83 +1,27 @@
 import React, { ReactNode } from 'react';
 
-import { fsx } from '../system/fsx';
+import { ConstantBadge } from './ConstantBadge';
+import { OutlineBadge } from './OutlineBadge';
+import { TextBadge } from './TextBadge';
 
-type Props = {
+export type BadgeProps = {
   color?: 'white' | 'gray' | 'primary' | 'native';
   icon?: ReactNode;
-  variant?: 'constant' | 'text' | 'outline';
   label: string;
 };
 
-export const Badge: React.FC<Props> = ({ color = 'white', icon, variant = 'constant', label }) => {
+export const Badge: React.FC<BadgeProps & { variant?: 'constant' | 'text' | 'outline' }> = ({
+  color = 'white',
+  icon,
+  variant = 'constant',
+  label,
+}) => {
   switch (variant) {
     case 'constant':
-      return (
-        <div
-          className={fsx([
-            'flex flex-row items-start gap-1 rounded',
-            color === 'white' && 'text-[#0B0D0E]',
-            color === 'primary' && 'text-[#005093]',
-            color === 'native' && 'text-[#C00F50]',
-          ])}
-        >
-          <div className="flex h-6 w-4 flex-row items-start py-1">{icon}</div>
-          <span className="text-r font-bold">{label}</span>
-        </div>
-      );
+      return <ConstantBadge color={color} icon={icon} label={label} />;
     case 'text':
-      return (
-        <div
-          className={fsx([
-            'flex flex-row items-center w-fit gap-1 text-r justify-center rounded px-2',
-            color === 'white' && 'bg-[#fff] text-[#0B0D0E]',
-            color === 'gray' && 'bg-[#F7F8F8] text-[#0B0D0E]',
-            color === 'primary' && 'bg-[#E0F4FD] text-[#005093]',
-            color === 'native' && 'bg-[#FBEEF1] text-[#C00F50]',
-          ])}
-        >
-          {icon && (
-            <div
-              className={fsx([
-                color === 'white' && 'text-[#B3BCC1]',
-                color === 'gray' && 'text-[#B3BCC1]',
-                color === 'primary' && 'text-[#7ACFF4]',
-                color === 'native' && 'text-[#F58DA9]',
-              ])}
-            >
-              {icon}
-            </div>
-          )}
-
-          <span>{label}</span>
-        </div>
-      );
+      return <TextBadge color={color} icon={icon} label={label} />;
     case 'outline':
-      return (
-        <div
-          className={fsx([
-            'flex flex-row items-center w-fit gap-1 text-r justify-center rounded outline px-2',
-            color === 'white' && 'bg-[#fff] text-[#0B0D0E] outline-[#EEF0F1]',
-            color === 'gray' && 'bg-[#F7F8F8] text-[#0B0D0E] outline-[#EEF0F1]',
-            color === 'primary' && 'bg-[#E0F4FD] text-[#005093] outline-[#AFE2F8]',
-            color === 'native' && 'bg-[#FBEEF1] text-[#C00F50] outline-[#F9BACB]',
-          ])}
-        >
-          {icon && (
-            <div
-              className={fsx([
-                color === 'white' && 'text-[#B3BCC1]',
-                color === 'gray' && 'text-[#B3BCC1]',
-                color === 'primary' && 'text-[#7ACFF4]',
-                color === 'native' && 'text-[#F58DA9]',
-              ])}
-            >
-              {icon}
-            </div>
-          )}
-
-          <span>{label}</span>
-        </div>
-      );
+      return <OutlineBadge color={color} icon={icon} label={label} />;
   }
 };

--- a/packages/for-ui/src/badge/Badge.tsx
+++ b/packages/for-ui/src/badge/Badge.tsx
@@ -1,25 +1,88 @@
 import React, { ReactNode } from 'react';
-import { BadgeProps } from '@mui/material/Badge';
-import MuiBadge from '@mui/material/Badge';
 
-interface Props extends BadgeProps {
-  className?: string;
-  children: ReactNode;
-}
+import { MdError } from 'react-icons/md';
+import { fsx } from '../system/fsx';
 
-export const Badge: React.FC<Props> = ({ className, badgeContent, children, ...rest }) => {
-  return (
-    <MuiBadge
-      badgeContent={badgeContent}
-      color="primary"
-      componentsProps={{
-        root: {
-          className: `text-shade-dark-default ${className}`,
-        },
-      }}
-      {...rest}
-    >
-      {children}
-    </MuiBadge>
-  );
+type Props = {
+  color?: 'white' | 'gray' | 'primary' | 'native';
+  icon?: ReactNode;
+  type?: 'constant' | 'text' | 'outline';
+  label: string;
+};
+
+export const Badge: React.FC<Props> = ({ color = 'white', icon, type = 'constant', label }) => {
+  switch (type) {
+    case 'constant':
+      return (
+        <div
+          className={fsx([
+            'flex flex-row items-start gap-1 rounded',
+            color === 'white' && 'text-[#0B0D0E]',
+            color === 'primary' && 'text-[#005093]',
+            color === 'native' && 'text-[#C00F50]',
+          ])}
+        >
+          <div className="flex h-6 w-4 flex-row items-start py-1">
+            <MdError className="h-4 w-4" />
+          </div>
+          <span className="text-r font-bold">{label}</span>
+        </div>
+      );
+    case 'text':
+      return (
+        <div
+          className={fsx([
+            'flex flex-row items-center w-fit gap-1 text-r justify-center rounded px-2',
+            color === 'white' && 'bg-[#fff] text-[#0B0D0E]',
+            color === 'gray' && 'bg-[#F7F8F8] text-[#0B0D0E]',
+            color === 'primary' && 'bg-[#E0F4FD] text-[#005093]',
+            color === 'native' && 'bg-[#FBEEF1] text-[#C00F50]',
+          ])}
+        >
+          {icon && (
+            <div
+              className={fsx([
+                color === 'white' && 'text-[#B3BCC1]',
+                color === 'gray' && 'text-[#B3BCC1]',
+                color === 'primary' && 'text-[#7ACFF4]',
+                color === 'native' && 'text-[#F58DA9]',
+              ])}
+            >
+              {icon}
+            </div>
+          )}
+
+          <span>{label}</span>
+        </div>
+      );
+    case 'outline':
+      return (
+        <div
+          className={fsx([
+            'flex flex-row items-center w-fit gap-1 text-r justify-center rounded outline px-2',
+            color === 'white' && 'bg-[#fff] text-[#0B0D0E] outline-[#EEF0F1]',
+            color === 'gray' && 'bg-[#F7F8F8] text-[#0B0D0E] outline-[#EEF0F1]',
+            color === 'primary' && 'bg-[#E0F4FD] text-[#005093] outline-[#AFE2F8]',
+            color === 'native' && 'bg-[#FBEEF1] text-[#C00F50] outline-[#F9BACB]',
+          ])}
+        >
+          {icon && (
+            <div
+              className={fsx([
+                color === 'white' && 'text-[#B3BCC1]',
+                color === 'gray' && 'text-[#B3BCC1]',
+                color === 'primary' && 'text-[#7ACFF4]',
+                color === 'native' && 'text-[#F58DA9]',
+              ])}
+            >
+              {icon}
+            </div>
+          )}
+
+          <span>{label}</span>
+        </div>
+      );
+    default:
+      return null;
+  }
 };

--- a/packages/for-ui/src/badge/ConstantBadge.tsx
+++ b/packages/for-ui/src/badge/ConstantBadge.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { fsx } from '../system/fsx';
+import { BadgeProps } from './Badge';
+
+export const ConstantBadge: React.FC<BadgeProps> = ({ color = 'white', icon, label }) => {
+  return (
+    <div
+      className={fsx([
+        'flex flex-row items-start gap-1 rounded',
+        color === 'white' && 'text-[#0B0D0E]',
+        color === 'primary' && 'text-[#005093]',
+        color === 'native' && 'text-[#C00F50]',
+      ])}
+    >
+      <div className="flex h-6 w-4 flex-row items-start py-1">{icon}</div>
+      <span className="text-r font-bold">{label}</span>
+    </div>
+  );
+};

--- a/packages/for-ui/src/badge/OutlineBadge.tsx
+++ b/packages/for-ui/src/badge/OutlineBadge.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { fsx } from '../system/fsx';
+import { BadgeProps } from './Badge';
+
+export const OutlineBadge: React.FC<BadgeProps> = ({ color = 'white', icon, label }) => {
+  return (
+    <div
+      className={fsx([
+        'flex flex-row items-center w-fit gap-1 text-r justify-center rounded outline px-2',
+        color === 'white' && 'bg-[#fff] text-[#0B0D0E] outline-[#EEF0F1]',
+        color === 'gray' && 'bg-[#F7F8F8] text-[#0B0D0E] outline-[#EEF0F1]',
+        color === 'primary' && 'bg-[#E0F4FD] text-[#005093] outline-[#AFE2F8]',
+        color === 'native' && 'bg-[#FBEEF1] text-[#C00F50] outline-[#F9BACB]',
+      ])}
+    >
+      {icon && (
+        <div
+          className={fsx([
+            color === 'white' && 'text-[#B3BCC1]',
+            color === 'gray' && 'text-[#B3BCC1]',
+            color === 'primary' && 'text-[#7ACFF4]',
+            color === 'native' && 'text-[#F58DA9]',
+          ])}
+        >
+          {icon}
+        </div>
+      )}
+
+      <span>{label}</span>
+    </div>
+  );
+};

--- a/packages/for-ui/src/badge/TextBadge.tsx
+++ b/packages/for-ui/src/badge/TextBadge.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { fsx } from '../system/fsx';
+import { BadgeProps } from './Badge';
+
+export const TextBadge: React.FC<BadgeProps> = ({ color = 'white', icon, label }) => {
+  return (
+    <div
+      className={fsx([
+        'flex flex-row items-center w-fit gap-1 text-r justify-center rounded px-2',
+        color === 'white' && 'bg-[#fff] text-[#0B0D0E]',
+        color === 'gray' && 'bg-[#F7F8F8] text-[#0B0D0E]',
+        color === 'primary' && 'bg-[#E0F4FD] text-[#005093]',
+        color === 'native' && 'bg-[#FBEEF1] text-[#C00F50]',
+      ])}
+    >
+      {icon && (
+        <div
+          className={fsx([
+            color === 'white' && 'text-[#B3BCC1]',
+            color === 'gray' && 'text-[#B3BCC1]',
+            color === 'primary' && 'text-[#7ACFF4]',
+            color === 'native' && 'text-[#F58DA9]',
+          ])}
+        >
+          {icon}
+        </div>
+      )}
+
+      <span>{label}</span>
+    </div>
+  );
+};

--- a/packages/for-ui/src/badge/index.tsx
+++ b/packages/for-ui/src/badge/index.tsx
@@ -1,1 +1,4 @@
 export * from './Badge';
+export * from './ConstantBadge';
+export * from './TextBadge';
+export * from './OutlineBadge';

--- a/packages/for-ui/src/badge/index.tsx
+++ b/packages/for-ui/src/badge/index.tsx
@@ -1,4 +1,1 @@
 export * from './Badge';
-export * from './ConstantBadge';
-export * from './TextBadge';
-export * from './OutlineBadge';


### PR DESCRIPTION
## チケット

- #908 

## 実装内容

- Badgeコンポーネントの新デザイン実装

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|   <img width="683" alt="スクリーンショット 2022-12-26 21 17 43" src="https://user-images.githubusercontent.com/67810971/209548188-85d46f76-58eb-4882-89fb-2814d0d6ad7e.png">     |     <img width="681" alt="スクリーンショット 2022-12-26 21 17 13" src="https://user-images.githubusercontent.com/67810971/209548144-d8454bc5-073d-4274-9c89-52a87c5b354c.png">   |

## 相談内容(あれば)

- muiベースだと実装厳しそうなのでプロパティだけ引き継ぎました
