### PR TITLE
fix(TextArea): `helperText` と `label` propsを追加

### DIFF
--- a/.changeset/nervous-icons-vanish.md
+++ b/.changeset/nervous-icons-vanish.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(TextArea): `helperText` と `label` propsを追加

--- a/packages/for-ui/src/textArea/TextArea.stories.tsx
+++ b/packages/for-ui/src/textArea/TextArea.stories.tsx
@@ -39,58 +39,81 @@ export const Default = (): JSX.Element => {
       <Text as="h3" size="l" weight="bold">
         TextArea
       </Text>
-      <Text as="label" size="s" weight="bold" className="text-shade-medium-default flex flex-col gap-1">
-        3行固定TextArea
-        <TextArea
-          rows={3}
-          autoComplete="on"
-          placeholder="4design@example.com"
-          error={!!errors['email']}
-          {...register('email')}
-        />
-      </Text>
-      <Text as="label" size="s" weight="bold" className="text-shade-medium-default flex flex-col gap-1">
-        改行すると行が増えるTextArea
-        <TextArea
-          required
-          autoComplete="on"
-          placeholder="4design@example.com"
-          error={!!errors['email']}
-          {...register('email')}
-        />
-      </Text>
-      <Text as="label" size="s" weight="bold" className="text-shade-medium-default flex flex-col gap-1">
-        最小2行 最大4行 TextArea
-        <TextArea
-          required
-          minRows={2}
-          maxRows={4}
-          autoComplete="on"
-          placeholder="4design@example.com"
-          error={!!errors['email']}
-          {...register('email')}
-        />
-      </Text>
-      <Text as="label" size="s" weight="bold" className="text-shade-medium-default flex flex-col gap-1">
-        <Text>
-          エラー
-          <Text className="text-negative-medium-default" weight="regular">
-            *
+
+      <TextArea
+        rows={3}
+        label="3行固定TextArea"
+        autoComplete="on"
+        placeholder="4design@example.com"
+        error={!!errors['email']}
+        {...register('email')}
+      />
+
+      <TextArea
+        label={
+          <Text>
+            改行すると行が増えるTextArea
+            <Text
+              weight="regular"
+              size="xs"
+              className="border-negative-medium-default text-negative-medium-default ml-1 rounded-full border px-1"
+            >
+              必須
+            </Text>
           </Text>
-        </Text>
-        <TextArea error autoComplete="on" placeholder="4design@example.com" {...register('email')} />
-      </Text>
-      <Text as="label" size="s" weight="bold" className="text-shade-medium-default flex flex-col gap-1">
+        }
+        required
+        autoComplete="on"
+        placeholder="4design@example.com"
+        error={!!errors['email']}
+        {...register('email')}
+      />
+
+      <TextArea
+        label="最小2行 最大4行 TextArea"
+        required
+        minRows={2}
+        maxRows={4}
+        autoComplete="on"
+        placeholder="4design@example.com"
+        error={!!errors['email']}
+        helperText="注: たくさん入力しても4行以上にはなりません"
+        {...register('email')}
+      />
+
+      <TextArea
+        label={
+          <Text size="l" weight="regular" className="text-shade-light-default">
+            エラー
+            <Text className="text-negative-medium-default" weight="regular">
+              *
+            </Text>
+          </Text>
+        }
+        error
+        autoComplete="on"
+        placeholder="4design@example.com"
+        {...register('email')}
+      />
+
+      <TextArea
+        error
+        autoComplete="on"
+        placeholder="4design@example.com"
+        {...register('email')}
+        label="エラー"
+        helperText="エラーがでてます"
+      />
+
+      <TextArea
+        label="disabled"
+        rows={3}
+        autoComplete="on"
+        placeholder="4design@example.com"
+        error={!!errors['email']}
         disabled
-        <TextArea
-          rows={3}
-          autoComplete="on"
-          placeholder="4design@example.com"
-          error={!!errors['email']}
-          disabled
-          {...register('email')}
-        />
-      </Text>
+        {...register('email')}
+      />
       <Button type="submit">登録する</Button>
     </form>
   );

--- a/packages/for-ui/src/textArea/TextArea.tsx
+++ b/packages/for-ui/src/textArea/TextArea.tsx
@@ -1,6 +1,7 @@
-import { forwardRef } from 'react';
+import { forwardRef, Fragment, isValidElement, ReactNode } from 'react';
 import TextareaAutosize, { TextareaAutosizeProps } from '@mui/base/TextareaAutosize';
 import { fsx } from '../system/fsx';
+import { Text } from '../text';
 
 export type TextAreaProps = Omit<TextareaAutosizeProps, 'disabled' | 'className' | 'minRows' | 'maxRows'> & {
   /**
@@ -14,6 +15,20 @@ export type TextAreaProps = Omit<TextareaAutosizeProps, 'disabled' | 'className'
    * @default false
    */
   disabled?: boolean;
+
+  /**
+   * エラーメッセージ等の副次的内容をユーザーに示すときに指定
+   *
+   * 文字列の場合はデフォルトのスタイルが適用され、ValidなReactElementを渡すと渡したものがそのまま描画されます。
+   */
+  helperText?: ReactNode;
+
+  /**
+   * ラベルを表示するときに指定
+   *
+   * 文字列の場合はデフォルトのスタイルが適用され、ValidなReactElementを渡すと渡したものがそのまま描画されます。
+   */
+  label?: ReactNode;
 
   className?: string;
 } & (
@@ -64,22 +79,53 @@ export type TextAreaProps = Omit<TextareaAutosizeProps, 'disabled' | 'className'
   );
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  ({ className, minRows, maxRows, rows, error, disabled, ...props }, ref) => {
+  ({ className, minRows, maxRows, rows, error, disabled, helperText, label, required, ...props }, ref) => {
     return (
-      <TextareaAutosize
-        {...props}
-        disabled={disabled}
-        minRows={rows || minRows}
-        maxRows={rows || maxRows}
-        className={fsx([
-          `w-full bg-shade-white-default ring-shade-medium-default ring-inset ring-1 text-r text-shade-dark-default placeholder:text-shade-light-default rounded h-auto py-2.5 px-3 font-sans font-normal placeholder:opacity-100  focus-visible:outline-none focus-visible:ring-primary-medium-active focus-visible:ring-2`,
-          error && `ring-negative-medium-default focus-visible:ring-negative-medium-default`,
-          disabled &&
-            `bg-shade-white-disabled ring-shade-medium-disabled text-shade-dark-disabled placeholder:text-shade-light-disabled cursor-not-allowed`,
-          className,
-        ])}
-        ref={ref}
-      />
+      <div className={fsx(`flex flex-col gap-1`)}>
+        <Text as="label" size="s" weight="bold" className="text-shade-medium-default flex flex-col gap-1">
+          <Fragment>
+            {isValidElement(label) ? (
+              <Fragment>{label}</Fragment>
+            ) : (
+              <Text>
+                {label}
+                {required && (
+                  <Text className="text-negative-medium-default" weight="regular">
+                    *
+                  </Text>
+                )}
+              </Text>
+            )}
+          </Fragment>
+          <TextareaAutosize
+            {...props}
+            disabled={disabled}
+            minRows={rows || minRows}
+            maxRows={rows || maxRows}
+            className={fsx([
+              `w-full bg-shade-white-default ring-shade-medium-default ring-inset ring-1 text-r text-shade-dark-default placeholder:text-shade-light-default rounded h-auto py-2.5 px-3 font-sans font-normal placeholder:opacity-100  focus-visible:outline-none focus-visible:ring-primary-medium-active focus-visible:ring-2`,
+              error && `ring-negative-medium-default focus-visible:ring-negative-medium-default`,
+              disabled &&
+                `bg-shade-white-disabled ring-shade-medium-disabled text-shade-dark-disabled placeholder:text-shade-light-disabled cursor-not-allowed`,
+              className,
+            ])}
+            ref={ref}
+          />
+        </Text>
+        <Fragment>
+          {isValidElement(label) ? (
+            <Fragment>{helperText}</Fragment>
+          ) : (
+            <Text
+              size="s"
+              weight="regular"
+              className={fsx([`text-shade-dark-default`, error && `text-negative-medium-default`])}
+            >
+              {helperText}
+            </Text>
+          )}
+        </Fragment>
+      </div>
     );
   }
 );


### PR DESCRIPTION
## チケット

- Close #956

## 実装内容

- helperTextとlabelを追加
  - 各サービスで上書きできるよう、ReactNodeを受け取るようにして、文字列以外を受け取るとデフォルトのスタイルでないもので描画できるようにしました

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|     <img width="1339" alt="image" src="https://user-images.githubusercontent.com/8467289/209755822-ef4f9f3c-33d4-482f-94d1-d68e07b7a9fc.png">   |     <img width="1338" alt="image" src="https://user-images.githubusercontent.com/8467289/209755790-26654727-33ea-43cd-82d2-b9610604cac2.png">   |

## 相談内容(あれば)

-
