### PR TITLE
fix(TextArea): classNameをrootのdivに渡るように修正

### DIFF
--- a/.changeset/lucky-rockets-smile.md
+++ b/.changeset/lucky-rockets-smile.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(TextArea): classNameをrootのdivに渡るように修正

--- a/packages/for-ui/src/textArea/TextArea.tsx
+++ b/packages/for-ui/src/textArea/TextArea.tsx
@@ -112,7 +112,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           />
         </Text>
         <Fragment>
-          {isValidElement(label) ? (
+          {isValidElement(helperText) ? (
             <Fragment>{helperText}</Fragment>
           ) : (
             <Text

--- a/packages/for-ui/src/textArea/TextArea.tsx
+++ b/packages/for-ui/src/textArea/TextArea.tsx
@@ -81,7 +81,7 @@ export type TextAreaProps = Omit<TextareaAutosizeProps, 'disabled' | 'className'
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   ({ className, minRows, maxRows, rows, error, disabled, helperText, label, required, ...props }, ref) => {
     return (
-      <div className={fsx(`flex flex-col gap-1`)}>
+      <div className={fsx(`w-full flex flex-col gap-1`, className)}>
         <Text as="label" size="s" weight="bold" className="text-shade-medium-default flex flex-col gap-1">
           <Fragment>
             {isValidElement(label) ? (
@@ -107,7 +107,6 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
               error && `ring-negative-medium-default focus-visible:ring-negative-medium-default`,
               disabled &&
                 `bg-shade-white-disabled ring-shade-medium-disabled text-shade-dark-disabled placeholder:text-shade-light-disabled cursor-not-allowed`,
-              className,
             ])}
             ref={ref}
           />


### PR DESCRIPTION
## チケット

- Close #966 

## 実装内容

- `className` がrootのdivに渡るようになっておらず、width等がうまく変更できていなかったのを修正
- デフォルトで `w-full` になるよう修正
- 間違ったバリデーションを修正 (labelではなくhelperTextが正しい)

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
