### PR TITLE
fix: `fullWidth` props を削除しデフォルトで `w-full` になるように修正

### DIFF
--- a/.changeset/grumpy-suits-retire.md
+++ b/.changeset/grumpy-suits-retire.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix: `fullWidth` propsを削除しデフォルトで `w-full` になるように修正

--- a/packages/for-ui/src/select/Select.stories.tsx
+++ b/packages/for-ui/src/select/Select.stories.tsx
@@ -93,6 +93,7 @@ export const Basic: Story = () => {
             return (
               <Select
                 name={name}
+                label="国名"
                 placeholder="国名"
                 options={options}
                 onChange={(e, option) => {

--- a/packages/for-ui/src/select/Select.tsx
+++ b/packages/for-ui/src/select/Select.tsx
@@ -24,7 +24,6 @@ export type AutocompleteProps = UseAutocompleteProps<SelectOption, boolean, bool
   label?: string;
   placeholder?: string;
   required?: boolean;
-  fullWidth?: boolean;
   loadingText?: React.ReactNode;
   disabled?: boolean;
   className?: string;
@@ -120,7 +119,7 @@ export const Select: FC<AutocompleteProps> = forwardRef<HTMLInputElement, Autoco
           );
         }}
         classes={{
-          root: fsx(['bg-shade-white-default', className]),
+          root: fsx(['bg-shade-white-default w-full', className]),
           paper: fsx(['min-w-min translate-y-4 rounded-2xl py-2']),
           inputRoot: fsx(['group bg-shade-white-default text-shade-light-default p-0 antialiased']),
           input: fsx([

--- a/packages/for-ui/src/textField/TextField.stories.tsx
+++ b/packages/for-ui/src/textField/TextField.stories.tsx
@@ -43,69 +43,44 @@ export const Outlined = (): JSX.Element => {
       <Text as="h3" size="l" weight="bold">
         Text Field
       </Text>
-      <div className="flex flex-col gap-1">
-        <TextField
-          required
-          fullWidth
-          error={!!errors['email']}
-          autoComplete="on"
-          type="email"
-          label="メールアドレス"
-          placeholder="example@example.com"
-          {...register('email')}
-        />
-        {errors['email'] && (
-          <Text size="s" className="text-negative-medium-default">
-            メールアドレスは必須です
-          </Text>
-        )}
-      </div>
 
-      <div>
-        <TextField
-          required
-          type="password"
-          label="パスワード"
-          placeholder="********"
-          error={!!errors['password']}
-          {...register('password')}
-        />
-        {errors['password'] && (
-          <Text size="s" className="text-negative-medium-default">
-            パスワードは必須です
-          </Text>
-        )}
-      </div>
+      <TextField
+        required
+        error={!!errors['email']}
+        autoComplete="on"
+        type="email"
+        label="メールアドレス"
+        placeholder="example@example.com"
+        helperText={errors['email'] && `メールアドレスは必須です`}
+        {...register('email')}
+      />
+      <TextField
+        required
+        type="password"
+        label="パスワード"
+        placeholder="********"
+        error={!!errors['password']}
+        helperText={errors['password'] && `パスワードは必須です`}
+        {...register('password')}
+      />
 
-      <div>
-        <TextField
-          label="金額 (2万円以上)"
-          placeholder="2"
-          unitLabel="万円"
-          isPriceFormat
-          error={!!errors['price']}
-          {...register('price')}
-        />
-        {errors['price'] && (
-          <Text size="s" className="text-negative-medium-default">
-            金額は2万円以上を入力してください
-          </Text>
-        )}
-      </div>
+      <TextField
+        label="金額 (2万円以上)"
+        placeholder="2"
+        unitLabel="万円"
+        isPriceFormat
+        error={!!errors['price']}
+        helperText={errors['price'] && `金額は2万円以上を入力してください`}
+        {...register('price')}
+      />
 
-      <div>
-        <TextField
-          label="アカウント名"
-          prefix="https://example.com/accounts/"
-          error={!!errors['account']}
-          {...register('account')}
-        />
-        {errors['account'] && (
-          <Text size="s" className="text-negative-medium-default">
-            エラーです
-          </Text>
-        )}
-      </div>
+      <TextField
+        label="アカウント名"
+        prefix="https://example.com/accounts/"
+        error={!!errors['account']}
+        helperText={errors['account'] && `エラーが発生しました`}
+        {...register('account')}
+      />
 
       <Button type="submit">登録する</Button>
     </form>

--- a/packages/for-ui/src/textField/TextField.tsx
+++ b/packages/for-ui/src/textField/TextField.tsx
@@ -61,8 +61,6 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       className,
       focused,
       placeholder,
-      // labelTwin,
-      // inputTwin,
       disabled,
       inputProps,
       required,
@@ -127,16 +125,11 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     return (
       <div className={fsx('flex flex-col w-full', className)}>
         <label>
-          {label && (
-            <p
-              className={fsx([
-                'text-s text-shade-medium-default mb-1 font-bold antialiased',
-                // labelTwin,
-              ])}
-            >
+          {(label || required) && (
+            <Text as="label" className={fsx(['text-s text-shade-medium-default mb-1 font-bold antialiased'])}>
               {label}
-              {required && <span className="text-negative-medium-default">*</span>}
-            </p>
+              {required && <Text className="text-negative-medium-default">*</Text>}
+            </Text>
           )}
           <MuiTextField
             disabled={disabled}
@@ -150,9 +143,10 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
                 '-webkit-text-fill-color': 'currentColor',
               },
             }}
+            className={fsx(`w-full flex flex-col gap-1`)}
             FormHelperTextProps={{
               classes: {
-                root: fsx([error && 'text-negative-medium-default m-0 mt-1 text-xs']),
+                root: fsx([error && 'text-negative-medium-default m-0 text-s']),
               },
             }}
             InputProps={{

--- a/packages/for-ui/src/textField/TextField.tsx
+++ b/packages/for-ui/src/textField/TextField.tsx
@@ -5,7 +5,7 @@ import { NumericFormat } from 'react-number-format';
 import { fsx } from '../system/fsx';
 import { Text } from '../text';
 
-export type TextFieldProps = Omit<MuiTextFieldProps, 'variant' | 'multiline' | 'rows' | 'margin'> & {
+export type TextFieldProps = Omit<MuiTextFieldProps, 'variant' | 'multiline' | 'rows' | 'margin' | 'fullWidth'> & {
   /**
    * 単位を表示する場合に指定してください。
    */
@@ -125,7 +125,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     );
 
     return (
-      <div className={fsx(['flex flex-col', className])}>
+      <div className={fsx('flex flex-col w-full', className)}>
         <label>
           {label && (
             <p


### PR DESCRIPTION
## チケット

- Close #968 

## 実装内容

- TextFieldとSelectに対して、`fullWidth` propsを削除しデフォルトで `w-full` になるように修正

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
