### PR TITLE
feat(Menu): `MenuList`コンポーネントを追加

### DIFF
--- a/packages/for-ui/src/menu/Menu.stories.tsx
+++ b/packages/for-ui/src/menu/Menu.stories.tsx
@@ -4,6 +4,7 @@ import { Meta } from '@storybook/react/types-6-0';
 import { Button } from '../button/Button';
 import { LegacyText as Text } from '../typography';
 import { Menu } from './Menu';
+import { MenuList } from './MenuList';
 import { MenuItem } from './MenuItem';
 
 export default {
@@ -15,7 +16,7 @@ export default {
   decorators: [
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (Story: any) => (
-      <div className="mt-10 flex h-screen w-screen flex-col gap-4">
+      <div className="flex h-full w-full flex-col gap-4">
         <Story />
       </div>
     ),
@@ -43,3 +44,11 @@ export const Base = () => {
     </div>
   );
 };
+
+export const Uncontrolled = () => (
+  <MenuList>
+    <MenuItem>プロフィール</MenuItem>
+    <MenuItem>設定</MenuItem>
+    <MenuItem>コンタクト</MenuItem>
+  </MenuList>
+);

--- a/packages/for-ui/src/menu/MenuList.tsx
+++ b/packages/for-ui/src/menu/MenuList.tsx
@@ -1,0 +1,14 @@
+import { forwardRef } from 'react';
+import MuiMenuList, { MenuListProps } from '@mui/material/MenuList';
+import { fsx } from '../system/fsx';
+
+export const MenuList = forwardRef<HTMLUListElement, MenuListProps>(({ className, ...rest }, ref) => (
+  <MuiMenuList
+    ref={ref}
+    className={fsx(
+      `z-modal shadow-menu w-full rounded p-1 divide-shade-light-default grid grid-cols-1 divide-y`,
+      className
+    )}
+    {...rest}
+  />
+));


### PR DESCRIPTION
## チケット

- Close #1007

## 実装内容

- MenuListコンポーネントを実装

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|    なし    |   <img width="1362" alt="image" src="https://user-images.githubusercontent.com/8467289/213452053-f1e77a0b-8bc2-41aa-8e05-a47b1a98768e.png">     |

## 相談内容(あれば)

-
