### PR TITLE
fix(Table): `onRowClick` が与えられているときにhover時のスタイルを適用

### DIFF
--- a/.changeset/stale-gifts-brake.md
+++ b/.changeset/stale-gifts-brake.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(Table): `onRowClick` が与えられているときにhover時のスタイルを適用

--- a/packages/for-ui/src/table/Table.stories.tsx
+++ b/packages/for-ui/src/table/Table.stories.tsx
@@ -80,3 +80,7 @@ export const WithTableScroller: Story = () => (
 export const WithTablePageSize: Story = () => (
   <Table<PersonData> columns={columns} data={StaticPersonData} pageSize={10} />
 );
+
+export const WithClickRow: Story = () => (
+  <Table<PersonData> columns={columns} data={StaticPersonData} pageSize={10} onRowClick={(_, row) => { console.info(row) }} />
+)

--- a/packages/for-ui/src/table/Table.stories.tsx
+++ b/packages/for-ui/src/table/Table.stories.tsx
@@ -82,5 +82,5 @@ export const WithTablePageSize: Story = () => (
 );
 
 export const WithClickRow: Story = () => (
-  <Table<PersonData> columns={columns} data={StaticPersonData} pageSize={10} onRowClick={(_, row) => { console.info(row) }} />
+  <Table<PersonData> columns={columns} data={StaticPersonData} disablePagination onRowClick={(_, row) => { console.info(row) }} />
 )

--- a/packages/for-ui/src/table/Table.stories.tsx
+++ b/packages/for-ui/src/table/Table.stories.tsx
@@ -82,5 +82,12 @@ export const WithTablePageSize: Story = () => (
 );
 
 export const WithClickRow: Story = () => (
-  <Table<PersonData> columns={columns} data={StaticPersonData} disablePagination onRowClick={(_, row) => { console.info(row) }} />
-)
+  <Table<PersonData>
+    columns={columns}
+    data={StaticPersonData}
+    disablePagination
+    onRowClick={(_, row) => {
+      console.info(row);
+    }}
+  />
+);

--- a/packages/for-ui/src/table/Table.tsx
+++ b/packages/for-ui/src/table/Table.tsx
@@ -220,10 +220,10 @@ export const Table = <T extends RowData>({
               key={row.id}
               row={row}
               selectable={!!(onSelectRow || onSelectRows)}
-              onClick={(e) => {
+              onClick={(onSelectRow || onSelectRows || onRowClick) && ((e, row) => {
                 selectRow(row);
                 onRowClick?.(e, row);
-              }}
+              })}
             />
           ))}
         </tbody>
@@ -237,7 +237,7 @@ export const Table = <T extends RowData>({
 export type RowProps<T extends RowData> = {
   row: RowType<T>;
   selectable: boolean;
-  onClick: (e: MouseEvent<HTMLTableRowElement>, row: RowType<T>) => void;
+  onClick?: (e: MouseEvent<HTMLTableRowElement>, row: RowType<T>) => void;
   className?: string;
 };
 
@@ -245,11 +245,11 @@ export const Row = <T extends RowData>({ row, selectable, onClick, className }: 
   <tr
     key={row.id}
     className={fsx([
-      'border-shade-light-default border-b transition duration-300 ease-in-out',
-      selectable && 'hover:bg-shade-light-default cursor-pointer',
+      'border-shade-light-default border-b transition-[background] duration-100',
+      (selectable || onClick) && 'hover:bg-shade-light-default cursor-pointer',
       className,
     ])}
-    onClick={(e) => onClick(e, row)}
+    onClick={(e) => onClick?.(e, row)}
   >
     {row.getVisibleCells().map((cell) => (
       <Fragment key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</Fragment>

--- a/packages/for-ui/src/table/Table.tsx
+++ b/packages/for-ui/src/table/Table.tsx
@@ -220,10 +220,13 @@ export const Table = <T extends RowData>({
               key={row.id}
               row={row}
               selectable={!!(onSelectRow || onSelectRows)}
-              onClick={(onSelectRow || onSelectRows || onRowClick) && ((e, row) => {
-                selectRow(row);
-                onRowClick?.(e, row);
-              })}
+              onClick={
+                (onSelectRow || onSelectRows || onRowClick) &&
+                ((e, row) => {
+                  selectRow(row);
+                  onRowClick?.(e, row);
+                })
+              }
             />
           ))}
         </tbody>


### PR DESCRIPTION
## チケット

- Close #1008

## 実装内容

- `onRowClick` が与えられているときにデフォルトのRowコンポーネントでhoverスタイルを適用するようにした

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|      <img width="1363" alt="image" src="https://user-images.githubusercontent.com/8467289/213607032-8aa46bdd-ac34-431a-a88e-d03b5e8e0ad1.png">  |     <img width="1364" alt="image" src="https://user-images.githubusercontent.com/8467289/213606989-90e1bc96-4422-4776-bf0a-11c68948500d.png">   |

## 相談内容(あれば)

-
