### PR TITLE
fix(Select): `error` と `helperText` propsに対応

### DIFF
--- a/.changeset/funny-comics-cry.md
+++ b/.changeset/funny-comics-cry.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(Select): `error` と `helperText` propsに対応

--- a/packages/for-ui/src/menu/MenuItem.tsx
+++ b/packages/for-ui/src/menu/MenuItem.tsx
@@ -14,7 +14,7 @@ export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>((props, ref) =>
       ref={ref}
       classes={{
         root: fsx([
-          'bg-shade-white-default text-r text-shade-dark-default hover:bg-shade-white-hover whitespace-nowrap border-solid py-2 pl-6 pr-12 font-sans',
+          `bg-shade-white-default text-r text-shade-dark-default hover:bg-shade-white-hover whitespace-nowrap border-solid py-2 pl-6 pr-12 font-sans focus-visible:bg-shade-white-active [&.Mui-focused]:bg-shade-white-active`,
           className,
         ]),
       }}

--- a/packages/for-ui/src/select/Select.stories.tsx
+++ b/packages/for-ui/src/select/Select.stories.tsx
@@ -115,18 +115,17 @@ export const Basic: Story = () => {
           control={control}
           render={({ field: { name, onChange } }) => {
             return (
-              <>
-                <Select
-                  name={name}
-                  required
-                  placeholder="国名"
-                  options={options}
-                  onChange={(e, option) => {
-                    onChange((option as SelectOption)?.inputValue);
-                  }}
-                />
-                <FormHelperText error>入力してください</FormHelperText>
-              </>
+              <Select
+                name={name}
+                required
+                placeholder="国名"
+                options={options}
+                onChange={(e, option) => {
+                  onChange((option as SelectOption)?.inputValue);
+                }}
+                error
+                helperText="入力してください"
+              />
             );
           }}
         />

--- a/packages/for-ui/src/select/Select.tsx
+++ b/packages/for-ui/src/select/Select.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactNode, forwardRef, Ref } from 'react';
+import { Fragment, ReactNode, forwardRef, Ref } from 'react';
 import Autocomplete, {
   AutocompleteProps as MuiAutocompleteProps,
   createFilterOptions,
@@ -19,19 +19,18 @@ export type SelectOption = {
   inputValue: string;
 };
 
-// const filter = createFilterOptions<SelectOption>();
-
 export type AutocompleteProps<
   Value extends SelectOption,
   Multiple extends boolean | undefined,
   FreeSolo extends boolean | undefined
 > = Omit<MuiAutocompleteProps<Value, Multiple, true, FreeSolo, 'div'>, 'autoComplete' | 'renderInput'> & {
-  // export type AutocompleteProps<T extends Object> = MuiAutocompleteProps<T, T, boolean ,boolean> & {
   name: string;
   label?: ReactNode;
   placeholder?: string;
   required?: boolean;
   loadingText?: ReactNode;
+  error?: boolean;
+  helperText?: ReactNode;
   disabled?: boolean;
   className?: string;
   disableFilter?: boolean;
@@ -52,6 +51,8 @@ const _Select = <
   multiple,
   freeSolo,
   onChange,
+  error,
+  helperText,
   disabled = false,
   disableFilter = false,
   inputRef,
@@ -138,22 +139,20 @@ const _Select = <
       );
     }}
     classes={{
-      root: fsx(['bg-shade-white-default w-full', className]),
-      paper: fsx(['min-w-min translate-y-4 rounded-2xl py-2']),
+      root: fsx(`bg-shade-white-default w-full`, className),
+      paper: fsx(`min-w-min translate-y-4 rounded-2xl py-2`),
       inputRoot: fsx([
-        'group bg-shade-white-default text-shade-light-default p-0 antialiased',
-        // 'group bg-shade-white-default text-shade-light-default antialiased !py-2',
-        disableFilter && 'cursor-pointer',
+        `group bg-shade-white-default text-shade-light-default p-0 antialiased`,
+        disableFilter && `cursor-pointer`,
       ]),
       input: fsx([
-        'text-r text-shade-dark-default placeholder:text-shade-light-default h-auto py-2.5 px-3 font-sans placeholder:opacity-100 focus:shadow-none',
-        // 'text-r text-shade-dark-default placeholder:text-shade-light-default h-auto font-sans placeholder:opacity-100 focus:shadow-none !p-0',
-        disableFilter && 'cursor-pointer caret-transparent',
+        `text-r text-shade-dark-default placeholder:text-shade-light-default h-auto py-2.5 px-3 font-sans placeholder:opacity-100 focus:shadow-none`,
+        disableFilter && `cursor-pointer caret-transparent`,
       ]),
-      inputFocused: fsx(['border-primary-medium-active']),
-      focused: fsx(['[&_svg]:!icon-shade-medium-active']),
-      tag: fsx(['bg-shade-light-default [&.MuiChip-deleteIcon]:text-shade-dark-default border-none']),
-      endAdornment: fsx(['[&_svg]:icon-shade-medium-default']),
+      inputFocused: fsx(`border-primary-medium-active`),
+      focused: fsx(`[&_svg]:!icon-shade-medium-active`),
+      tag: fsx(`bg-shade-light-default [&.MuiChip-deleteIcon]:text-shade-dark-default border-none`),
+      endAdornment: fsx(`[&_svg]:icon-shade-medium-default`),
     }}
     renderInput={(params) => {
       return (
@@ -173,8 +172,9 @@ const _Select = <
           name={name}
           required={required}
           label={label}
-          // inputTwin={inputTwin}
           placeholder={placeholder}
+          error={error}
+          helperText={helperText}
         />
       );
     }}

--- a/packages/for-ui/src/textField/TextField.tsx
+++ b/packages/for-ui/src/textField/TextField.tsx
@@ -89,7 +89,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         endAdornment: (
           <InputAdornment
             classes={{
-              root: fsx(['text-r text-shade-dark-default mr-3 font-sans antialiased']),
+              root: fsx(['text-r text-shade-dark-default mr-3 font-sans']),
             }}
             position="start"
             disableTypography
@@ -123,72 +123,70 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     );
 
     return (
-      <div className={fsx('flex flex-col w-full', className)}>
-        <label>
-          {label && (
-            <Text as="label" className={fsx(['text-s text-shade-medium-default mb-1 font-bold antialiased'])}>
-              {label}
-              {required && <Text className="text-negative-medium-default">*</Text>}
-            </Text>
-          )}
-          <MuiTextField
-            disabled={disabled}
-            error={error}
-            inputRef={validRef}
-            required={required}
-            variant="outlined"
-            placeholder={placeholder}
-            sx={{
-              '& .MuiInputBase-input:disabled::placeholder': {
-                '-webkit-text-fill-color': 'currentColor',
-              },
-            }}
-            className={fsx(`w-full flex flex-col gap-1`)}
-            FormHelperTextProps={{
-              classes: {
-                root: fsx([error && 'text-negative-medium-default m-0 text-s']),
-              },
-            }}
-            InputProps={{
-              classes: {
-                root: fsx(['group bg-shade-white-default text-shade-light-default px-0 antialiased']),
-                disabled: fsx(['bg-shade-white-disabled', 'placeholder:text-shade-light-default']),
-                input: fsx([
-                  'text-r text-shade-dark-default placeholder:text-shade-light-default h-auto py-2.5 px-3 font-sans placeholder:opacity-100 focus:shadow-none',
-                ]),
-                focused: fsx(['border-primary-medium-active']),
-                notchedOutline: fsx([
-                  'border',
-                  disabled
-                    ? 'border-shade-medium-disabled'
-                    : error
-                    ? 'border-negative-medium-default'
-                    : _focused
-                    ? 'border-2 border-primary-medium-active group-hover:border-primary-dark-default'
-                    : 'border-shade-medium-default group-hover:border-primary-dark-default',
-                ]),
-                inputAdornedEnd: fsx(['pr-2']),
-              },
-              startAdornment: prefix && (
-                <InputAdornment
-                  position="start"
-                  classes={{
-                    root: 'border-r border-shade-light-default bg-shade-light-default max-h-[fit-content] h-full py-2.5 px-3 m-0',
-                  }}
-                >
-                  <Text className="text-shade-dark-default inline-flex">{prefix}</Text>
-                </InputAdornment>
-              ),
-              ...InputProps,
-              ..._InputProps,
-            }}
-            inputProps={inputProps}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            {...rest}
-          />
-        </label>
-      </div>
+      <Text as="label" className={fsx('flex flex-col w-full gap-1', className)}>
+        {label && (
+          <Text className={fsx(['text-s text-shade-medium-default font-bold'])}>
+            {label}
+            {required && <Text className="text-negative-medium-default">*</Text>}
+          </Text>
+        )}
+        <MuiTextField
+          disabled={disabled}
+          error={error}
+          inputRef={validRef}
+          required={required}
+          variant="outlined"
+          placeholder={placeholder}
+          sx={{
+            '& .MuiInputBase-input:disabled::placeholder': {
+              '-webkit-text-fill-color': 'currentColor',
+            },
+          }}
+          className={fsx(`w-full flex flex-col gap-1`)}
+          FormHelperTextProps={{
+            classes: {
+              root: fsx([error && 'text-negative-medium-default m-0 text-s']),
+            },
+          }}
+          InputProps={{
+            classes: {
+              root: fsx(['group bg-shade-white-default text-shade-light-default px-0 antialiased']),
+              disabled: fsx(['bg-shade-white-disabled', 'placeholder:text-shade-light-default']),
+              input: fsx([
+                'text-r text-shade-dark-default placeholder:text-shade-light-default h-auto py-2.5 px-3 font-sans placeholder:opacity-100 focus:shadow-none',
+              ]),
+              focused: fsx(['border-primary-medium-active']),
+              notchedOutline: fsx([
+                'border',
+                disabled
+                  ? 'border-shade-medium-disabled'
+                  : error
+                  ? 'border-negative-medium-default'
+                  : _focused
+                  ? 'border-2 border-primary-medium-active group-hover:border-primary-dark-default'
+                  : 'border-shade-medium-default group-hover:border-primary-dark-default',
+              ]),
+              inputAdornedEnd: fsx(['pr-2']),
+            },
+            startAdornment: prefix && (
+              <InputAdornment
+                position="start"
+                classes={{
+                  root: 'border-r border-shade-light-default bg-shade-light-default max-h-[fit-content] h-full py-2.5 px-3 m-0',
+                }}
+              >
+                <Text className="text-shade-dark-default inline-flex">{prefix}</Text>
+              </InputAdornment>
+            ),
+            ...InputProps,
+            ..._InputProps,
+          }}
+          inputProps={inputProps}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          {...rest}
+        />
+      </Text>
     );
   }
 );


### PR DESCRIPTION
## チケット

- Close #979 

## 実装内容

- Selectを `error` と `helperText` propsに対応させる
  - 受け取ったpropsをTextFieldに渡して対応
- TextFieldのlabelをクリックしてもfocusしない問題を修正
- MenuItemをカーソルキーで選択しているときに表示がない問題を修正

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
