### PR TITLE
fix(Radio, Switch, Checkbox, TextArea): `label`, `error`, `helperText` propsの仕様を揃える

### DIFF
--- a/.changeset/nine-kings-pull.md
+++ b/.changeset/nine-kings-pull.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+Fix/error helpertext spec@1005

--- a/.changeset/nine-kings-pull.md
+++ b/.changeset/nine-kings-pull.md
@@ -2,4 +2,4 @@
 "@4design/for-ui": patch
 ---
 
-Fix/error helpertext spec@1005
+fix(Radio, Switch, Checkbox, TextArea): `label`, `error`, `helperText` propsの仕様を揃える

--- a/packages/for-ui/src/checkbox/Checkbox.stories.tsx
+++ b/packages/for-ui/src/checkbox/Checkbox.stories.tsx
@@ -1,10 +1,13 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Meta } from '@storybook/react/types-6-0';
 import { useForm } from 'react-hook-form';
-
-import { Button } from '../button';
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { fsx } from '../system/fsx';
 import { Checkbox } from './Checkbox';
-import { LegacyText as Text } from '../typography';
+import { CheckboxGroup } from './CheckboxGroup';
+import { Button } from '../button';
+import { Text } from '../text';
 
 export default {
   title: 'Form / Checkbox',
@@ -20,7 +23,7 @@ export const Basic = (): JSX.Element => {
     <form onSubmit={handleSubmit(onSubmit)}>
       <div>
         <div className="border-shade-light-default rounded-md border p-6 pb-8">
-          <Text variant="p" bold className="mb-1">
+          <Text as="p" weight="bold" className="mb-1">
             ラベル
           </Text>
 
@@ -46,7 +49,7 @@ export const WithNopadding = (): JSX.Element => {
     <form onSubmit={handleSubmit(onSubmit)}>
       <div>
         <div className="border-shade-light-default rounded-md border p-6 pb-8">
-          <Text variant="p" bold className="mb-1">
+          <Text as="p" weight="bold" className="mb-1">
             ラベル
           </Text>
 
@@ -63,3 +66,50 @@ export const WithNopadding = (): JSX.Element => {
     </form>
   );
 };
+
+const allPreferences = {
+  spring: '春',
+  summer: '夏',
+  autumn: '秋',
+  winter: '冬',
+} as const;
+
+const schema = yup.object({
+  preferences: yup.object(Object.fromEntries(Object.keys(allPreferences).map((k) => [k, yup.boolean()]))),
+});
+
+type FieldValue = yup.InferType<typeof schema>;
+
+export const WithCheckboxGroup = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FieldValue>({
+    resolver: yupResolver(schema),
+  });
+  const onSubmit = useCallback((data: unknown) => {
+    console.info(data);
+  }, []);
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className={fsx(`flex flex-col gap-8`)}>
+      <CheckboxGroup
+        required
+        label="好きな季節"
+        error={!!errors['preferences']}
+        helperText={errors['preferences'] && '必須です'}
+      >
+        <Checkbox label="春" value={true} {...register('preferences.spring')} />
+        <Checkbox label="夏" value={true} {...register('preferences.summer')} />
+        <Checkbox label="秋" value={true} {...register('preferences.autumn')} />
+        <Checkbox label="冬" value={true} {...register('preferences.winter')} />
+        <Checkbox label="雨季" value={true} disabled />
+      </CheckboxGroup>
+      <Button type="submit">保存</Button>
+    </form>
+  );
+};
+
+export const CustomLabel = () => (
+  <Checkbox label={<Text size="xl" weight="bold" className="text-shade-medium-default">ラベル</Text>} />
+)

--- a/packages/for-ui/src/checkbox/Checkbox.stories.tsx
+++ b/packages/for-ui/src/checkbox/Checkbox.stories.tsx
@@ -111,5 +111,11 @@ export const WithCheckboxGroup = () => {
 };
 
 export const CustomLabel = () => (
-  <Checkbox label={<Text size="xl" weight="bold" className="text-shade-medium-default">ラベル</Text>} />
-)
+  <Checkbox
+    label={
+      <Text size="xl" weight="bold" className="text-shade-medium-default">
+        ラベル
+      </Text>
+    }
+  />
+);

--- a/packages/for-ui/src/checkbox/Checkbox.tsx
+++ b/packages/for-ui/src/checkbox/Checkbox.tsx
@@ -1,44 +1,41 @@
+import { forwardRef, ReactNode } from 'react';
 import MuiCheckbox, { CheckboxProps as MuiCheckboxProps } from '@mui/material/Checkbox';
-import FormControlLabel from '@mui/material/FormControlLabel';
 import { fsx } from '../system/fsx';
 import { Text } from '../text';
+import { TextDefaultStyler } from '../system/TextDefaultStyler';
 
 export type CheckboxProps = MuiCheckboxProps & {
-  label?: string;
+  label?: ReactNode;
   nopadding?: boolean;
   // Checbox SVG Font Size
   iconsize?: number | string;
   className?: string;
 };
 
-const _Checkbox = ({ nopadding = false, iconsize = 28, className, ...rest }: CheckboxProps) => (
-  <MuiCheckbox
-    classes={{
-      root: fsx('text-shade-medium-default', className, nopadding ? 'p-0' : 'p-1'),
-      checked: fsx('text-secondary-dark-default'),
-      disabled: fsx('text-shade-dark-disabled'),
-    }}
-    sx={{ '& .MuiSvgIcon-root': { fontSize: iconsize } }}
-    {...rest}
-  />
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ label, iconsize, nopadding = false, disabled, className, ...rest }, ref) => (
+    <Text as="label" className={fsx(`group inline-flex w-[max-content] flex-row gap-2 items-center`, className)}>
+      <MuiCheckbox
+        classes={{
+          root: fsx('text-shade-medium-default', nopadding ? 'p-0' : 'p-1'),
+          checked: fsx('text-secondary-dark-default'),
+          disabled: fsx('text-shade-dark-disabled'),
+        }}
+        disabled={disabled}
+        sx={{ '& .MuiSvgIcon-root': { fontSize: iconsize } }}
+        inputRef={ref}
+        {...rest}
+      />
+      <TextDefaultStyler
+        content={label}
+        defaultRenderer={(props) => (
+          <Text
+            size="s"
+            className={fsx(`text-shade-dark-default`, disabled && `text-shade-dark-disabled`)}
+            {...props}
+          />
+        )}
+      />
+    </Text>
+  )
 );
-
-export const Checkbox = ({ label, nopadding = false, disabled, className, ...rest }: CheckboxProps) => {
-  return (
-    <>
-      {label ? (
-        <FormControlLabel
-          className={fsx(`m-0`, className)}
-          control={<_Checkbox nopadding={nopadding} {...rest} />}
-          label={
-            <Text size="s" className={fsx(`text-shade-dark-default ml-2`, disabled && `text-shade-dark-disabled`)}>
-              {label}
-            </Text>
-          }
-        />
-      ) : (
-        <_Checkbox nopadding={nopadding} className={className} {...rest} />
-      )}
-    </>
-  );
-};

--- a/packages/for-ui/src/checkbox/CheckboxGroup.tsx
+++ b/packages/for-ui/src/checkbox/CheckboxGroup.tsx
@@ -1,0 +1,62 @@
+import { forwardRef, ReactNode } from 'react';
+import FormControl from '@mui/material/FormControl';
+import FormGroup, { FormGroupProps } from '@mui/material/FormGroup';
+import { Text } from '../text';
+import { fsx } from '../system/fsx';
+import { TextDefaultStyler } from '../system/TextDefaultStyler';
+
+export type CheckboxGroupProps = Omit<FormGroupProps, 'defaultValue' | 'defaultChecked'> & {
+  name?: string;
+  row?: boolean;
+  required?: boolean;
+  disabled?: boolean;
+  label?: ReactNode;
+  error?: boolean;
+  helperText?: ReactNode;
+  className?: string;
+  children: ReactNode;
+};
+
+export const CheckboxGroup = forwardRef<HTMLInputElement, CheckboxGroupProps>(
+  ({ required, disabled, label, error, row, helperText, className, ...rest }, ref) => {
+    return (
+      <FormControl
+        component="fieldset"
+        required={required}
+        disabled={disabled}
+        error={error}
+        className={fsx(`flex flex-col gap-2`, className)}
+      >
+        <TextDefaultStyler
+          content={label}
+          defaultRenderer={({ children, ...props }) => (
+            <Text as="legend" size="s" weight="bold" className={fsx(`text-shade-medium-default contents`)} {...props}>
+              {/* due to the CSS bug, legend element cannot be styled if contents not specified. But contents makes difficult to style, so wrap by Text. */}
+              <Text>
+                {children}
+                {required && <Text className={fsx(`text-negative-medium-default`)}>*</Text>}
+              </Text>
+            </Text>
+          )}
+        />
+        <FormGroup
+          row={row}
+          className={fsx(`flex flex-wrap gap-x-6 gap-y-1`, row && `flex-row`)}
+          ref={ref}
+          {...rest}
+        />
+        <TextDefaultStyler
+          content={helperText}
+          defaultRenderer={(props) => (
+            <Text
+              size="s"
+              weight="regular"
+              className={fsx(`text-shade-dark-default`, error && `text-negative-medium-default`)}
+              {...props}
+            />
+          )}
+        />
+      </FormControl>
+    );
+  }
+);

--- a/packages/for-ui/src/checkbox/CheckboxGroup.tsx
+++ b/packages/for-ui/src/checkbox/CheckboxGroup.tsx
@@ -39,12 +39,7 @@ export const CheckboxGroup = forwardRef<HTMLInputElement, CheckboxGroupProps>(
             </Text>
           )}
         />
-        <FormGroup
-          row={row}
-          className={fsx(`flex flex-wrap gap-x-6 gap-y-1`, row && `flex-row`)}
-          ref={ref}
-          {...rest}
-        />
+        <FormGroup row={row} className={fsx(`flex flex-wrap gap-x-6 gap-y-1`, row && `flex-row`)} ref={ref} {...rest} />
         <TextDefaultStyler
           content={helperText}
           defaultRenderer={(props) => (

--- a/packages/for-ui/src/radio/Radio.stories.tsx
+++ b/packages/for-ui/src/radio/Radio.stories.tsx
@@ -1,9 +1,13 @@
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useCallback } from 'react';
 import { Meta } from '@storybook/react/types-6-0';
-
-import { LegacyText as Text } from '../typography';
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
 import { Radio } from './Radio';
 import { RadioGroup } from './RadioGroup';
+import { useForm } from 'react-hook-form';
+import { Button } from '../button';
+import { Text } from '../text';
+import { fsx } from '../system/fsx';
 
 export default {
   title: 'Form / Radio',
@@ -16,9 +20,6 @@ export default {
       </div>
     ),
   ],
-  argTypes: {
-    backgroundColor: { control: 'color' },
-  },
 } as Meta;
 
 export const Base = (): JSX.Element => {
@@ -31,7 +32,9 @@ export const Base = (): JSX.Element => {
   return (
     <div className="flex flex-col gap-8">
       <div className="mb-4 border-b">
-        <Text variant="h3">Radio</Text>
+        <Text as="h3" weight="bold" size="l">
+          Radio
+        </Text>
       </div>
 
       <div>
@@ -42,7 +45,7 @@ export const Base = (): JSX.Element => {
       </div>
 
       <div>
-        <RadioGroup required label="サービス名" onChange={handleRadioChange} error="必須項目です">
+        <RadioGroup row required label="サービス名" onChange={handleRadioChange} error helperText="必須項目です">
           <Radio label="Relance" value="relance" />
           <Radio label="Sreake Sonar" value="sreake-sonar" />
           <Radio label="Reckoner" value="reckoner" disabled />
@@ -60,11 +63,13 @@ export const WithLabel = (): JSX.Element => {
   return (
     <div className="flex flex-col gap-8">
       <div className="mb-4 border-b">
-        <Text variant="h3">Radio</Text>
+        <Text as="h3" weight="bold" size="l">
+          Radio
+        </Text>{' '}
       </div>
 
       <div>
-        <RadioGroup required label="サービス名" onChange={handleRadioChange}>
+        <RadioGroup row required label="サービス名" onChange={handleRadioChange}>
           <Radio label="Relance" value="relance" />
           <Radio label="Sreake Sonar" value="sreake-sonar" />
           <Radio label="Reckoner" value="reckoner" disabled />
@@ -72,7 +77,7 @@ export const WithLabel = (): JSX.Element => {
       </div>
 
       <div>
-        <RadioGroup required label="サービス名" onChange={handleRadioChange} error="必須項目です">
+        <RadioGroup row required label="サービス名" onChange={handleRadioChange} error helperText="必須項目です">
           <Radio label="Relance" value="relance" />
           <Radio label="Sreake Sonar" value="sreake-sonar" />
           <Radio label="Reckoner" value="reckoner" disabled />
@@ -90,11 +95,13 @@ export const WithNopadding = (): JSX.Element => {
   return (
     <div className="flex flex-col gap-8">
       <div className="mb-4 border-b">
-        <Text variant="h3">Radio</Text>
+        <Text as="h3" weight="bold" size="l">
+          Radio
+        </Text>{' '}
       </div>
 
       <div>
-        <RadioGroup required label="サービス名" onChange={handleRadioChange}>
+        <RadioGroup row required label="サービス名" onChange={handleRadioChange}>
           <Radio nopadding label="Relance" value="relance" />
           <Radio nopadding label="Sreake Sonar" value="sreake-sonar" />
           <Radio nopadding label="Reckoner" value="reckoner" disabled />
@@ -103,3 +110,50 @@ export const WithNopadding = (): JSX.Element => {
     </div>
   );
 };
+
+const preferences = {
+  spring: '春',
+  summer: '夏',
+  autumn: '秋',
+  winter: '冬',
+} as const;
+
+const schema = yup.object({
+  preference: yup.string().oneOf(Object.keys(preferences)).required(),
+});
+
+type FieldValue = yup.InferType<typeof schema>;
+
+export const WithRadioGroup = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FieldValue>({
+    resolver: yupResolver(schema),
+  });
+  const onSubmit = useCallback((data: FieldValue) => {
+    console.info(data);
+  }, []);
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className={fsx(`flex flex-col gap-8`)}>
+      <RadioGroup
+        required
+        label="好きな季節"
+        error={!!errors['preference']}
+        helperText={errors['preference'] && '選択してください'}
+        defaultValue="summer"
+        {...register('preference')}
+      >
+        <Radio label="春" value="spring" />
+        <Radio label="夏" value="summer" />
+        <Radio label="秋" value="autumn" />
+        <Radio label="冬" value="winter" />
+        <Radio label="雨季" value="rainy_season" disabled />
+      </RadioGroup>
+      <Button type="submit">保存</Button>
+    </form>
+  );
+};
+
+export const CustomLabel = () => <Radio label={<p className={fsx(`text-xl text-shade-medium-default`)}>hello</p>} />;

--- a/packages/for-ui/src/radio/Radio.tsx
+++ b/packages/for-ui/src/radio/Radio.tsx
@@ -1,64 +1,54 @@
-import { FC, Fragment, memo, forwardRef } from 'react';
-import FormControlLabel from '@mui/material/FormControlLabel';
+import { FC, forwardRef, ReactNode } from 'react';
 import MuiRadio, { RadioProps as MuiRadioProps } from '@mui/material/Radio';
 import { fsx } from '../system/fsx';
+import { Text } from '../text';
+import { TextDefaultStyler } from '../system/TextDefaultStyler';
 
-export interface RadioProps extends MuiRadioProps {
-  label?: string;
-  error?: string;
+export type RadioProps = Omit<MuiRadioProps, 'ref'> & {
+  label?: ReactNode;
   nopadding?: boolean;
   className?: string;
-}
+};
 
 const Indicator: FC<{ checked: boolean; disabled: boolean }> = ({ checked, disabled }) => (
   <span
     className={fsx([
-      'bg-shade-white-default h-5 w-5 rounded-full transition-[border-width] duration-100',
-      checked ? 'border-7' : 'group-hover:border-3 group-hover:border-secondary-dark-default border-2',
+      `bg-shade-white-default h-5 w-5 rounded-full transition-[border-width] duration-100`,
+      checked ? `border-7` : `border-2`,
       disabled
-        ? 'border-shade-medium-disabled'
+        ? `border-shade-medium-disabled`
         : checked
-        ? 'border-secondary-dark-default'
-        : 'border-shade-medium-default',
+        ? `border-secondary-dark-default`
+        : `border-shade-medium-default group-hover:border-3 group-hover:border-secondary-dark-default`,
     ])}
   />
 );
 
-const _Radio: FC<RadioProps> = memo(({ nopadding, disabled, ref, ...rest }) => (
-  <MuiRadio
-    disableRipple
-    icon={<Indicator checked={false} disabled={!!disabled} />}
-    checkedIcon={<Indicator checked={true} disabled={!!disabled} />}
-    disabled={disabled}
-    classes={{
-      root: fsx(['group hover:bg-transparent', nopadding ? 'p-0' : 'p-1']),
-    }}
-    inputRef={ref}
-    {...rest}
-  />
-));
-
-export const Radio: FC<RadioProps> = forwardRef<HTMLButtonElement, RadioProps>(
-  ({ label, value, disabled, className, ...rest }, ref) => {
-    return (
-      <Fragment>
-        {label ? (
-          <FormControlLabel
-            disabled={disabled}
-            value={value}
-            label={label}
-            control={<_Radio value={value} disabled={disabled} ref={ref} {...rest} />}
-            ref={ref}
-            classes={{
-              root: fsx('group m-0 flex gap-2', className),
-              label: fsx('text-s text-shade-dark-default font-sans'),
-              disabled: fsx('text-shade-dark-disabled'),
-            }}
+export const Radio = forwardRef<HTMLInputElement, RadioProps>(
+  ({ nopadding, label, value, disabled, className, ...rest }, ref) => (
+    <Text as="label" className={fsx(`group inline-flex w-[max-content] flex-row gap-2 items-center`, className)}>
+      <MuiRadio
+        disableRipple
+        value={value}
+        disabled={disabled}
+        inputRef={ref}
+        icon={<Indicator checked={false} disabled={!!disabled} />}
+        checkedIcon={<Indicator checked={true} disabled={!!disabled} />}
+        classes={{
+          root: fsx(`group hover:bg-transparent`, nopadding ? `p-0` : `p-1`),
+        }}
+        {...rest}
+      />
+      <TextDefaultStyler
+        content={label}
+        defaultRenderer={(props) => (
+          <Text
+            size="s"
+            className={fsx(`text-shade-dark-default`, disabled && `text-shade-dark-disabled`)}
+            {...props}
           />
-        ) : (
-          <_Radio value={value} disabled={disabled} ref={ref} {...rest} />
         )}
-      </Fragment>
-    );
-  }
+      />
+    </Text>
+  )
 );

--- a/packages/for-ui/src/radio/RadioGroup.tsx
+++ b/packages/for-ui/src/radio/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   forwardRef,
   ReactNode,
   PropsWithoutRef,

--- a/packages/for-ui/src/radio/RadioGroup.tsx
+++ b/packages/for-ui/src/radio/RadioGroup.tsx
@@ -1,58 +1,83 @@
-import React from 'react';
+import React, {
+  forwardRef,
+  ReactNode,
+  PropsWithoutRef,
+  Children,
+  isValidElement,
+  cloneElement,
+  ComponentProps,
+} from 'react';
 import FormControl from '@mui/material/FormControl';
-import FormHelperText from '@mui/material/FormHelperText';
 import MuiRadioGroup, { RadioGroupProps as MuiRadioGroupProps } from '@mui/material/RadioGroup';
+import { Text } from '../text';
 import { fsx } from '../system/fsx';
+import { TextDefaultStyler } from '../system/TextDefaultStyler';
+import { Radio } from './Radio';
 
-export interface RadioGroupProps extends MuiRadioGroupProps {
-  children: React.ReactNode;
+export type RadioGroupProps = Omit<PropsWithoutRef<MuiRadioGroupProps>, 'color'> & {
+  name?: string;
+  row?: boolean;
+  disabled?: boolean;
   required?: boolean;
-  label?: string;
-  error?: string;
+  label?: ReactNode;
+  error?: boolean;
+  helperText?: ReactNode;
   className?: string;
-}
-
-export const RadioGroup: React.VFC<RadioGroupProps> = ({
-  className,
-  name,
-  label,
-  defaultValue,
-  row = true,
-  error,
-  children,
-  onChange,
-  required = false,
-}) => {
-  return (
-    <FormControl component="fieldset" error={!!error}>
-      {label && (
-        <label className="text-s text-shade-medium-default mb-2 font-sans">
-          {label}
-          {required && <span className="text-negative-medium-default">*</span>}
-        </label>
-      )}
-      <MuiRadioGroup
-        row={row}
-        name={name}
-        defaultValue={defaultValue}
-        classes={{
-          error: fsx(['text-negative-medium-default m-0 mt-1']),
-        }}
-        className={fsx([`flex gap-x-6 gap-y-2`, className])}
-        onChange={onChange}
-      >
-        {children}
-      </MuiRadioGroup>
-      {error && (
-        <FormHelperText
-          classes={{
-            root: fsx(['text-negative-medium-default']),
-            error: fsx(['text-negative-medium-default m-0 mt-1']),
-          }}
-        >
-          {error}
-        </FormHelperText>
-      )}
-    </FormControl>
-  );
+  children: ReactNode;
 };
+
+export const RadioGroup = forwardRef<HTMLInputElement, RadioGroupProps>(
+  (
+    { className, name, label, row, defaultValue, error, helperText, children, required = false, disabled, ...rest },
+    ref
+  ) => (
+    <FormControl
+      component="fieldset"
+      required={required}
+      disabled={disabled}
+      error={error}
+      className={fsx(`flex flex-col gap-2`, className)}
+    >
+      <TextDefaultStyler
+        content={label}
+        defaultRenderer={({ children, ...props }) => (
+          <Text as="legend" size="s" weight="bold" className={fsx(`text-shade-medium-default contents`)} {...props}>
+            {/* due to the CSS bug, legend element cannot be styled if contents not specified. But contents makes difficult to style, so wrap by Text. */}
+            <Text>
+              {children}
+              {required && <Text className={fsx(`text-negative-medium-default`)}>*</Text>}
+            </Text>
+          </Text>
+        )}
+      />
+      <MuiRadioGroup
+        name={name}
+        row={row}
+        defaultValue={defaultValue}
+        className={fsx(`flex flex-wrap gap-x-6 gap-y-2`, row && `flex-row`, className)}
+        {...rest}
+        ref={ref}
+      >
+        {
+          // Pass ref to children (Radio) if provided to RadioGroup
+          Children.map(children, (child) =>
+            isValidElement<ComponentProps<typeof Radio>>(child)
+              ? cloneElement(child, { ref: ref ? ref : undefined })
+              : child
+          )
+        }
+      </MuiRadioGroup>
+      <TextDefaultStyler
+        content={helperText}
+        defaultRenderer={(props) => (
+          <Text
+            size="s"
+            weight="regular"
+            className={fsx(`text-shade-dark-default`, error && `text-negative-medium-default`)}
+            {...props}
+          />
+        )}
+      />
+    </FormControl>
+  )
+);

--- a/packages/for-ui/src/radio/RadioGroup.tsx
+++ b/packages/for-ui/src/radio/RadioGroup.tsx
@@ -1,12 +1,4 @@
-import {
-  forwardRef,
-  ReactNode,
-  PropsWithoutRef,
-  Children,
-  isValidElement,
-  cloneElement,
-  ComponentProps,
-} from 'react';
+import { forwardRef, ReactNode, PropsWithoutRef, Children, isValidElement, cloneElement, ComponentProps } from 'react';
 import FormControl from '@mui/material/FormControl';
 import MuiRadioGroup, { RadioGroupProps as MuiRadioGroupProps } from '@mui/material/RadioGroup';
 import { Text } from '../text';

--- a/packages/for-ui/src/radio/RadioGroup.tsx
+++ b/packages/for-ui/src/radio/RadioGroup.tsx
@@ -54,9 +54,9 @@ export const RadioGroup = forwardRef<HTMLInputElement, RadioGroupProps>(
         name={name}
         row={row}
         defaultValue={defaultValue}
-        className={fsx(`flex flex-wrap gap-x-6 gap-y-2`, row && `flex-row`, className)}
-        {...rest}
+        className={fsx(`flex flex-wrap gap-x-6 gap-y-2`, row && `flex-row`)}
         ref={ref}
+        {...rest}
       >
         {
           // Pass ref to children (Radio) if provided to RadioGroup

--- a/packages/for-ui/src/switch/Switch.stories.tsx
+++ b/packages/for-ui/src/switch/Switch.stories.tsx
@@ -7,7 +7,7 @@ import { fsx } from '../system/fsx';
 import { Switch } from './Switch';
 import { SwitchGroup } from './SwitchGroup';
 import { Button } from '../button';
-import { Text } from '../text'
+import { Text } from '../text';
 
 export default {
   title: 'Form / Switch',
@@ -78,5 +78,11 @@ export const WithSwitchGroup = () => {
 };
 
 export const CustomLabel = () => (
-  <Switch label={<Text size="xl" weight="bold" className="text-shade-medium-default">ラベル</Text>} />
-)
+  <Switch
+    label={
+      <Text size="xl" weight="bold" className="text-shade-medium-default">
+        ラベル
+      </Text>
+    }
+  />
+);

--- a/packages/for-ui/src/switch/Switch.stories.tsx
+++ b/packages/for-ui/src/switch/Switch.stories.tsx
@@ -1,7 +1,13 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Meta } from '@storybook/react/types-6-0';
-
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useForm } from 'react-hook-form';
+import { fsx } from '../system/fsx';
 import { Switch } from './Switch';
+import { SwitchGroup } from './SwitchGroup';
+import { Button } from '../button';
+import { Text } from '../text'
 
 export default {
   title: 'Form / Switch',
@@ -27,3 +33,50 @@ export const Base = {
     disabled: false,
   },
 };
+
+const allPreferences = {
+  spring: '春',
+  summer: '夏',
+  autumn: '秋',
+  winter: '冬',
+} as const;
+
+const schema = yup.object({
+  preferences: yup.object(Object.fromEntries(Object.keys(allPreferences).map((k) => [k, yup.boolean()]))),
+});
+
+type FieldValue = yup.InferType<typeof schema>;
+
+export const WithSwitchGroup = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FieldValue>({
+    resolver: yupResolver(schema),
+  });
+  const onSubmit = useCallback((data: unknown) => {
+    console.info(data);
+  }, []);
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className={fsx(`flex flex-col gap-8`)}>
+      <SwitchGroup
+        required
+        label="好きな季節"
+        error={!!errors['preferences']}
+        helperText={errors['preferences'] && '必須です'}
+      >
+        <Switch label="春" value={true} {...register('preferences.spring')} />
+        <Switch label="夏" value={true} {...register('preferences.summer')} />
+        <Switch label="秋" value={true} {...register('preferences.autumn')} />
+        <Switch label="冬" value={true} {...register('preferences.winter')} />
+        <Switch label="雨季" value={true} disabled />
+      </SwitchGroup>
+      <Button type="submit">保存</Button>
+    </form>
+  );
+};
+
+export const CustomLabel = () => (
+  <Switch label={<Text size="xl" weight="bold" className="text-shade-medium-default">ラベル</Text>} />
+)

--- a/packages/for-ui/src/switch/Switch.tsx
+++ b/packages/for-ui/src/switch/Switch.tsx
@@ -1,36 +1,48 @@
-import React from 'react';
-import FormControlLabel, { FormControlLabelProps } from '@mui/material/FormControlLabel';
-import MuiSwitch from '@mui/material/Switch';
+import { forwardRef, ReactNode } from 'react';
+import MuiSwitch, { SwitchProps as MuiSwitchProps } from '@mui/material/Switch';
 import { fsx } from '../system/fsx';
+import { Text } from '../text';
+import { TextDefaultStyler } from '../system/TextDefaultStyler';
 
-export type SwitchProps = Omit<FormControlLabelProps, 'control'> & {
-  value?: unknown;
+export type SwitchProps = Omit<MuiSwitchProps, 'control'> & {
+  label?: ReactNode;
   className?: string;
 };
 
-export const Switch: React.FC<SwitchProps> = ({ value, checked, disabled, className, ...rest }) => {
-  return (
-    <FormControlLabel
-      control={
-        <MuiSwitch
-          value={value}
-          checked={checked}
-          disabled={disabled}
-          classes={{
-            root: fsx('my-2 mr-2 h-6 w-11 p-0', className),
-            track: fsx(
-              'bg-primary-dark-default block h-full w-full rounded-xl opacity-100',
-              checked && 'bg-secondary-dark-default opacity-100',
-              disabled && 'bg-primary-dark-disabled opacity-100',
-              checked && disabled && 'bg-secondary-dark-disabled opacity-100'
-            ),
-            thumb: fsx(
-              'bg-shade-white-default absolute top-1 left-1 h-4 w-4 rounded-2xl transition-all duration-200 ease-in'
-            ),
-          }}
-        />
-      }
-      {...rest}
-    />
-  );
-};
+export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
+  ({ label, checked, disabled, className, ...rest }, ref) => (
+    <Text as="label" className={fsx(`group inline-flex w-[max-content] flex-row gap-2 items-center`, className)}>
+      <MuiSwitch
+        checked={checked}
+        disabled={disabled}
+        inputRef={ref}
+        classes={{
+          root: fsx('my-2 mr-2 h-6 w-11 p-0', className),
+          track: fsx(
+            'bg-primary-dark-default block h-full w-full rounded-xl opacity-100',
+            checked && 'bg-secondary-dark-default opacity-100',
+            // FIXME: Fix to use checked CSS state (NOT checked variable) and root element instead of track.
+            // Otherwise uncontrolled switch does not perform as expected to show active state.
+            `[.Mui-checked+&]:bg-secondary-dark-default`,
+            disabled && 'bg-primary-dark-disabled opacity-100',
+            checked && disabled && 'bg-secondary-dark-disabled opacity-100'
+          ),
+          thumb: fsx(
+            'bg-shade-white-default absolute top-1 left-1 h-4 w-4 rounded-2xl transition-all duration-200 ease-in'
+          ),
+        }}
+        {...rest}
+      />
+      <TextDefaultStyler
+        content={label}
+        defaultRenderer={(props) => (
+          <Text
+            size="s"
+            className={fsx(`text-shade-dark-default`, disabled && `text-shade-dark-disabled`)}
+            {...props}
+          />
+        )}
+      />
+    </Text>
+  )
+);

--- a/packages/for-ui/src/switch/SwitchGroup.tsx
+++ b/packages/for-ui/src/switch/SwitchGroup.tsx
@@ -39,12 +39,7 @@ export const SwitchGroup = forwardRef<HTMLInputElement, SwitchGroupProps>(
             </Text>
           )}
         />
-        <FormGroup
-          row={row}
-          className={fsx(`flex flex-wrap gap-x-6 gap-y-1`, row && `flex-row`)}
-          ref={ref}
-          {...rest}
-        />
+        <FormGroup row={row} className={fsx(`flex flex-wrap gap-x-6 gap-y-1`, row && `flex-row`)} ref={ref} {...rest} />
         <TextDefaultStyler
           content={helperText}
           defaultRenderer={(props) => (

--- a/packages/for-ui/src/switch/SwitchGroup.tsx
+++ b/packages/for-ui/src/switch/SwitchGroup.tsx
@@ -1,33 +1,72 @@
-import React from 'react';
+import React, { forwardRef, ReactNode, Children, isValidElement, cloneElement, ComponentProps } from 'react';
 import FormControl from '@mui/material/FormControl';
-import FormGroup from '@mui/material/FormGroup';
-import FormHelperText from '@mui/material/FormHelperText';
-import FormLabel from '@mui/material/FormLabel';
-import { RadioGroupProps as MuiRadioGroupProps } from '@mui/material/RadioGroup';
+import FormGroup, { FormGroupProps } from '@mui/material/FormGroup';
+import { Text } from '../text';
+import { fsx } from '../system/fsx';
+import { TextDefaultStyler } from '../system/TextDefaultStyler';
+import { Switch } from './Switch';
 
-export interface RadioGroupProps extends MuiRadioGroupProps {
-  children: React.ReactNode;
-  required?: boolean;
-  label?: string;
+export type SwitchGroupProps = Omit<FormGroupProps, 'defaultValue' | 'defaultChecked'> & {
+  name?: string;
   row?: boolean;
-  error?: string;
-}
-
-export const SwitchGroup: React.VFC<RadioGroupProps> = ({ label, error, row = false, children }) => {
-  return (
-    <FormControl component="fieldset" error={!!error}>
-      {label && <FormLabel component="legend">{label}</FormLabel>}
-      <FormGroup row={row}>{children}</FormGroup>
-      {error && (
-        <FormHelperText
-          classes={{
-            root: 'text-negative-medium-default',
-            error: 'text-negative-medium-default',
-          }}
-        >
-          {error}
-        </FormHelperText>
-      )}
-    </FormControl>
-  );
+  required?: boolean;
+  disabled?: boolean;
+  label?: ReactNode;
+  error?: boolean;
+  helperText?: ReactNode;
+  className?: string;
+  children: ReactNode;
 };
+
+export const SwitchGroup = forwardRef<HTMLInputElement, SwitchGroupProps>(
+  ({ required, disabled, label, error, row, children, helperText, className, ...rest }, ref) => {
+    return (
+      <FormControl
+        component="fieldset"
+        required={required}
+        disabled={disabled}
+        error={error}
+        className={fsx(`flex flex-col gap-2`, className)}
+      >
+        <TextDefaultStyler
+          content={label}
+          defaultRenderer={({ children, ...props }) => (
+            <Text as="legend" size="s" weight="bold" className={fsx(`text-shade-medium-default contents`)} {...props}>
+              {/* due to the CSS bug, legend element cannot be styled if contents not specified. But contents makes difficult to style, so wrap by Text. */}
+              <Text>
+                {children}
+                {required && <Text className={fsx(`text-negative-medium-default`)}>*</Text>}
+              </Text>
+            </Text>
+          )}
+        />
+        <FormGroup
+          row={row}
+          className={fsx(`flex flex-wrap gap-x-6 gap-y-1`, row && `flex-row`, className)}
+          {...rest}
+          ref={ref}
+        >
+          {
+            // Pass ref to children (Radio) if provided to RadioGroup
+            Children.map(children, (child) =>
+              isValidElement<ComponentProps<typeof Switch>>(child)
+                ? cloneElement(child, { ref: ref ? ref : undefined })
+                : child
+            )
+          }
+        </FormGroup>
+        <TextDefaultStyler
+          content={helperText}
+          defaultRenderer={(props) => (
+            <Text
+              size="s"
+              weight="regular"
+              className={fsx(`text-shade-dark-default`, error && `text-negative-medium-default`)}
+              {...props}
+            />
+          )}
+        />
+      </FormControl>
+    );
+  }
+);

--- a/packages/for-ui/src/switch/SwitchGroup.tsx
+++ b/packages/for-ui/src/switch/SwitchGroup.tsx
@@ -1,10 +1,9 @@
-import React, { forwardRef, ReactNode, Children, isValidElement, cloneElement, ComponentProps } from 'react';
+import { forwardRef, ReactNode } from 'react';
 import FormControl from '@mui/material/FormControl';
 import FormGroup, { FormGroupProps } from '@mui/material/FormGroup';
 import { Text } from '../text';
 import { fsx } from '../system/fsx';
 import { TextDefaultStyler } from '../system/TextDefaultStyler';
-import { Switch } from './Switch';
 
 export type SwitchGroupProps = Omit<FormGroupProps, 'defaultValue' | 'defaultChecked'> & {
   name?: string;
@@ -19,7 +18,7 @@ export type SwitchGroupProps = Omit<FormGroupProps, 'defaultValue' | 'defaultChe
 };
 
 export const SwitchGroup = forwardRef<HTMLInputElement, SwitchGroupProps>(
-  ({ required, disabled, label, error, row, children, helperText, className, ...rest }, ref) => {
+  ({ required, disabled, label, error, row, helperText, className, ...rest }, ref) => {
     return (
       <FormControl
         component="fieldset"
@@ -42,19 +41,10 @@ export const SwitchGroup = forwardRef<HTMLInputElement, SwitchGroupProps>(
         />
         <FormGroup
           row={row}
-          className={fsx(`flex flex-wrap gap-x-6 gap-y-1`, row && `flex-row`, className)}
-          {...rest}
+          className={fsx(`flex flex-wrap gap-x-6 gap-y-1`, row && `flex-row`)}
           ref={ref}
-        >
-          {
-            // Pass ref to children (Radio) if provided to RadioGroup
-            Children.map(children, (child) =>
-              isValidElement<ComponentProps<typeof Switch>>(child)
-                ? cloneElement(child, { ref: ref ? ref : undefined })
-                : child
-            )
-          }
-        </FormGroup>
+          {...rest}
+        />
         <TextDefaultStyler
           content={helperText}
           defaultRenderer={(props) => (

--- a/packages/for-ui/src/system/TextDefaultStyler.tsx
+++ b/packages/for-ui/src/system/TextDefaultStyler.tsx
@@ -1,0 +1,16 @@
+import { FC, isValidElement, ReactNode, ReactElement } from 'react';
+
+export type TextDefaultStylerProps = {
+  content: ReactNode;
+  defaultRenderer: FC<{ children: Exclude<ReactNode, ReactElement> }>;
+};
+
+export const TextDefaultStyler: FC<TextDefaultStylerProps> = ({ content, defaultRenderer: DefaultRenderer }) => {
+  if (!content) {
+    return null;
+  }
+  if (isValidElement(content)) {
+    return content;
+  }
+  return <DefaultRenderer>{content}</DefaultRenderer>;
+};

--- a/packages/for-ui/src/textArea/TextArea.tsx
+++ b/packages/for-ui/src/textArea/TextArea.tsx
@@ -1,7 +1,8 @@
-import { forwardRef, Fragment, isValidElement, ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 import TextareaAutosize, { TextareaAutosizeProps } from '@mui/base/TextareaAutosize';
 import { fsx } from '../system/fsx';
 import { Text } from '../text';
+import { TextDefaultStyler } from '../system/TextDefaultStyler';
 
 export type TextAreaProps = Omit<TextareaAutosizeProps, 'disabled' | 'className' | 'minRows' | 'maxRows'> & {
   /**
@@ -82,21 +83,20 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   ({ className, minRows, maxRows, rows, error, disabled, helperText, label, required, ...props }, ref) => {
     return (
       <div className={fsx(`w-full flex flex-col gap-1`, className)}>
-        <Text as="label" size="s" weight="bold" className="text-shade-medium-default flex flex-col gap-1">
-          <Fragment>
-            {isValidElement(label) ? (
-              <Fragment>{label}</Fragment>
-            ) : (
-              <Text>
-                {label}
-                {label && required && (
-                  <Text className="text-negative-medium-default" weight="regular">
+        <Text as="label" className={fsx(`flex flex-col gap-1`)}>
+          <TextDefaultStyler
+            content={label}
+            defaultRenderer={({ children, ...props }) => (
+              <Text {...props} size="s" weight="bold" className={fsx(`text-shade-medium-default`)}>
+                {children}
+                {children && required && (
+                  <Text className={fsx(`text-negative-medium-default`)} weight="regular">
                     *
                   </Text>
                 )}
               </Text>
             )}
-          </Fragment>
+          />
           <TextareaAutosize
             {...props}
             disabled={disabled}
@@ -111,19 +111,17 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
             ref={ref}
           />
         </Text>
-        <Fragment>
-          {isValidElement(helperText) ? (
-            <Fragment>{helperText}</Fragment>
-          ) : (
+        <TextDefaultStyler
+          content={helperText}
+          defaultRenderer={(props) => (
             <Text
               size="s"
               weight="regular"
-              className={fsx([`text-shade-dark-default`, error && `text-negative-medium-default`])}
-            >
-              {helperText}
-            </Text>
+              className={fsx(`text-shade-dark-default`, error && `text-negative-medium-default`)}
+              {...props}
+            />
           )}
-        </Fragment>
+        />
       </div>
     );
   }


### PR DESCRIPTION
## チケット

- Close #1005 

## 実装内容

- labelとerrorとhelperTextの仕様を揃える
  - label: ReactNodeを受け取り、stringであればデフォルトのスタイルを、ReactElementであればそのまま表示する
  - error: booleanにして、エラーメッセージはhelperTextで描画するように揃える
  - helperText: ReactNodeを受け取り、stringであればデフォルトのスタイルを、ReactElementであればそのまま表示する
- 上記の仕様のため、TextDefaultStylerというユーティリティコンポーネントを作成
  - content propsをReactNodeにして、stringであればdefaultRendererで受け取ったコンポーネントで、ReactNodeであればそのまま描画する
- Checkbox、Radio、Switchのlabel等を改修、forwardRefに改修
- RadioGroup: 受け取ったrefをchildren (Radio) に流すようにする
  - これにより、RadioGroupにreact-hook-formのregisterを渡すと個別のRadioに設定しなくても値が取れるようになった ([参考](https://github.com/4-design/for-ui/pull/1038/files#diff-ecea0fc5e105e2cb8f14bfb6bd346514b3ad2eea88387a59fc88c28f9acf027fR140-R153)) 
- CheckboxGroup: 追加
- TextArea: TextDefaultStylerを使うように修正

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
