### PR TITLE
fix(TextField): `suffix` と `icon` propsの追加とprefixとsuffixのデザイン修正

### DIFF
--- a/.changeset/spicy-zoos-enjoy.md
+++ b/.changeset/spicy-zoos-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": minor
+---
+
+fix(TextField): `suffix` と `icon` propsの追加とprefixとsuffixのデザイン修正

--- a/packages/for-ui/src/textField/TextField.stories.tsx
+++ b/packages/for-ui/src/textField/TextField.stories.tsx
@@ -7,11 +7,38 @@ import * as yup from 'yup';
 import { Button } from '../button/Button';
 import { TextField } from './TextField';
 import { Text } from '../text';
+import { MdOutlineSearch } from 'react-icons/md';
+import { MdDeleteOutline, MdOutlineEdit, MdOutlinePhone, MdOutlineMail } from 'react-icons/md';
+
+const sampleIcons = {
+  undefined,
+  MdOutlineSearch: <MdOutlineSearch />,
+  MdDeleteOutline: <MdDeleteOutline />,
+  MdOutlineEdit: <MdOutlineEdit />,
+  MdOutlinePhone: <MdOutlinePhone />,
+  MdOutlineMail: <MdOutlineMail />,
+};
 
 export default {
   title: 'Form / TextField',
   component: TextField,
+  argTypes: {
+    icon: {
+      options: Object.keys(sampleIcons),
+      mapping: sampleIcons,
+    },
+  },
 } as Meta;
+
+export const Playground = {
+  args: {
+    prefix: '',
+    suffix: '',
+    label: 'ラベル',
+    required: false,
+    disabled: false,
+  },
+};
 
 const schema = yup.object({
   email: yup.string().required(),
@@ -22,11 +49,7 @@ const schema = yup.object({
 
 type FieldValue = yup.InferType<typeof schema>;
 
-export const Playground = {
-  prefix: '',
-};
-
-export const Outlined = (): JSX.Element => {
+export const Base = (): JSX.Element => {
   const {
     register,
     handleSubmit,
@@ -55,6 +78,7 @@ export const Outlined = (): JSX.Element => {
           helperText={errors['email'] && `メールアドレスは必須です`}
           {...register('email')}
         />
+
         <TextField
           required
           type="password"
@@ -68,7 +92,7 @@ export const Outlined = (): JSX.Element => {
         <TextField
           label="金額 (2万円以上)"
           placeholder="2"
-          unitLabel="万円"
+          suffix="万円"
           isPriceFormat
           error={!!errors['price']}
           helperText={errors['price'] && `金額は2万円以上を入力してください`}
@@ -117,7 +141,7 @@ export const Outlined = (): JSX.Element => {
           size="medium"
           label="金額 (2万円以上)"
           placeholder="2"
-          unitLabel="万円"
+          suffix="万円"
           isPriceFormat
           error={!!errors['price']}
           helperText={errors['price'] && `金額は2万円以上を入力してください`}
@@ -138,3 +162,5 @@ export const Outlined = (): JSX.Element => {
     </div>
   );
 };
+
+export const WithIcon = () => <TextField icon={<MdOutlineSearch />} />;


### PR DESCRIPTION
## チケット

- Close #1009 

## 実装内容

- `unitLabel` をより汎用的な `suffix` propsに変更
- suffixとprefixのデザインを最新のものに修正
- 内部のリファクタリング
  - errorやhelperTextの仕様を他と揃えたため、必要なくなった部分を落としTextFieldではなくOutlinedInputを使用し少し軽くした
  - スタイル周りを見やすく修正
- focus時のスタイルをCSSで記述するように修正
- `icon` propsを導入し、iconを指定しやすくした

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|   <img width="1409" alt="image" src="https://user-images.githubusercontent.com/8467289/217729699-bcb18894-2d7a-4e8b-8c0b-e6b6da021a18.png">     |     <img width="1410" alt="image" src="https://user-images.githubusercontent.com/8467289/217729755-8bbd6444-05e3-43c1-825b-961cd296c953.png">   |

## 相談内容(あれば)

-
