### PR TITLE
fix(TextArea): 自動サイズ調整が効かないバグの修正

### DIFF
--- a/.changeset/itchy-avocados-itch.md
+++ b/.changeset/itchy-avocados-itch.md
@@ -2,4 +2,4 @@
 "@4design/for-ui": patch
 ---
 
-fix(TextArea): 自動サイズ調整が効かないバグの修正と型定義の暫定的修正
+fix(TextArea): 自動サイズ調整が効かないバグの修正

--- a/packages/for-ui/src/textArea/TextArea.tsx
+++ b/packages/for-ui/src/textArea/TextArea.tsx
@@ -34,8 +34,8 @@ export type TextAreaProps = Omit<TextareaAutosizeProps, 'disabled' | 'className'
   className?: string;
 
   // FIXME: ライブラリインポート側でonReizeとonResizeCaptureがrequiredになってしまうバグがあり、その暫定修正
-  onResize?: TextareaAutosizeProps['onResize']
-  onResizeCapture?: TextareaAutosizeProps['onResizeCapture']
+  onResize?: TextareaAutosizeProps['onResize'];
+  onResizeCapture?: TextareaAutosizeProps['onResizeCapture'];
 } & (
     | {
         /**

--- a/packages/for-ui/src/textArea/TextArea.tsx
+++ b/packages/for-ui/src/textArea/TextArea.tsx
@@ -103,7 +103,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
             minRows={rows || minRows}
             maxRows={rows || maxRows}
             className={fsx([
-              `w-full bg-shade-white-default ring-shade-medium-default ring-inset ring-1 text-r text-shade-dark-default placeholder:text-shade-light-default rounded h-auto py-2.5 px-3 font-sans font-normal placeholder:opacity-100  focus-visible:outline-none focus-visible:ring-primary-medium-active focus-visible:ring-2`,
+              `w-full bg-shade-white-default ring-shade-medium-default ring-inset ring-1 text-r text-shade-dark-default placeholder:text-shade-light-default rounded py-2.5 px-3 font-sans font-normal placeholder:opacity-100  focus-visible:outline-none focus-visible:ring-primary-medium-active focus-visible:ring-2`,
               error && `ring-negative-medium-default focus-visible:ring-negative-medium-default`,
               disabled &&
                 `bg-shade-white-disabled ring-shade-medium-disabled text-shade-dark-disabled placeholder:text-shade-light-disabled cursor-not-allowed`,

--- a/packages/for-ui/src/textArea/TextArea.tsx
+++ b/packages/for-ui/src/textArea/TextArea.tsx
@@ -32,6 +32,10 @@ export type TextAreaProps = Omit<TextareaAutosizeProps, 'disabled' | 'className'
   label?: ReactNode;
 
   className?: string;
+
+  // FIXME: ライブラリインポート側でonReizeとonResizeCaptureがrequiredになってしまうバグがあり、その暫定修正
+  onResize?: TextareaAutosizeProps['onResize']
+  onResizeCapture?: TextareaAutosizeProps['onResizeCapture']
 } & (
     | {
         /**

--- a/packages/for-ui/src/textArea/TextArea.tsx
+++ b/packages/for-ui/src/textArea/TextArea.tsx
@@ -32,10 +32,6 @@ export type TextAreaProps = Omit<TextareaAutosizeProps, 'disabled' | 'className'
   label?: ReactNode;
 
   className?: string;
-
-  // FIXME: ライブラリインポート側でonReizeとonResizeCaptureがrequiredになってしまうバグがあり、その暫定修正
-  onResize?: TextareaAutosizeProps['onResize'];
-  onResizeCapture?: TextareaAutosizeProps['onResizeCapture'];
 } & (
     | {
         /**


### PR DESCRIPTION
## チケット

- Close #1047 
- https://3shake.slack.com/archives/C03L73GNHB2/p1673579874504209

## 実装内容

- 不要な `h-auto` 削除
- ~~`onResize` `onResizeCapture` propsがなぜかライブラリからインポートしてきたときだけrequiredになるバグがあるので暫定的に修正~~ FUI側では根本的な対策ができなさそうなので使う側で対処してもらうことにした
  - https://github.com/4-design/for-ui/discussions/1051

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
