### PR TITLE
fix(Skeleton): 戻り値の不正なパスを修正

### DIFF
--- a/.changeset/angry-buttons-suffer.md
+++ b/.changeset/angry-buttons-suffer.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(Skeleton): 戻り値の不正なパスを修正

--- a/packages/for-ui/src/skeleton/Skeleton.stories.tsx
+++ b/packages/for-ui/src/skeleton/Skeleton.stories.tsx
@@ -3,11 +3,18 @@ import Avatar from '@mui/material/Avatar';
 import AvatarGroup from '@mui/material/AvatarGroup';
 import { Meta } from '@storybook/react/types-6-0';
 
-import { LegacyText as Text, LegacyTypography as Typography } from '../typography';
+import { Text } from '../text';
 import { Skeleton, SkeletonX } from './Skeleton';
 
+export const Playground = {
+  args: {
+    loading: true,
+    children: undefined,
+  },
+};
+
 export default {
-  title: 'Example / Skeleton',
+  title: 'Feedback / Skeleton',
   component: Skeleton,
   decorators: [
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,22 +39,34 @@ export const WithText = () => {
   return (
     <div className="flex flex-col">
       <Skeleton loading={loading}>
-        <Typography variant="h1">H1. Heading</Typography>
+        <Text size="xl" as="h1">
+          H1. Heading
+        </Text>
       </Skeleton>
       <Skeleton loading={loading}>
-        <Typography variant="h2">H2. Heading</Typography>
+        <Text size="l" as="h2">
+          H2. Heading
+        </Text>
       </Skeleton>
       <Skeleton loading={loading}>
-        <Typography variant="h3">H3. Heading</Typography>
+        <Text size="xr" as="h3">
+          H3. Heading
+        </Text>
       </Skeleton>
       <Skeleton loading={loading}>
-        <Typography variant="h4">H4. Heading</Typography>
+        <Text size="r" as="h4">
+          H4. Heading
+        </Text>
       </Skeleton>
       <Skeleton loading={loading}>
-        <Typography variant="h5">H5. Heading</Typography>
+        <Text size="s" as="h5">
+          H5. Heading
+        </Text>
       </Skeleton>
       <Skeleton loading={loading}>
-        <Typography variant="h6">H6. Heading</Typography>
+        <Text size="xs" as="h6">
+          H6. Heading
+        </Text>
       </Skeleton>
     </div>
   );
@@ -121,8 +140,12 @@ export const WithCount = () => {
   return (
     <div className="flex flex-col">
       <Skeleton loading={loading} count={10}>
-        <Typography variant="h1">H1. Heading</Typography>
-        <Typography variant="h1">H1. Heading</Typography>
+        <Text size="xl" as="h1">
+          H1. Heading
+        </Text>
+        <Text size="xl" as="h1">
+          H1. Heading
+        </Text>
       </Skeleton>
     </div>
   );
@@ -140,63 +163,53 @@ export const WithNest = () => {
     <div className="flex flex-col">
       <SkeletonX loading={loading} variant="text">
         <Row>
-          <Text bold variant="caption" className="text-shade-dark-default mb-2">
+          <Text weight="bold" className="text-shade-dark-default mb-2">
             サービス名
           </Text>
 
-          <Text variant="caption" className="text-shade-dark-default">
-            {undefined}
-          </Text>
+          <Text className="text-shade-dark-default">{undefined}</Text>
         </Row>
 
         <Row>
-          <Text bold variant="caption" className="text-shade-dark-default">
+          <Text weight="bold" className="text-shade-dark-default">
             サービス概要
           </Text>
 
-          <Text variant="caption" className="text-shade-dark-default">
+          <Text className="text-shade-dark-default">
             「Reckoner」は、個人が簡単にモノの売り買いが楽しめるフリマアプリです。AIによる不正の監視や独自の入金システムにより、誰でも安心・安全な取引が行えます。
           </Text>
         </Row>
 
         <Row>
-          <Text bold variant="caption" className="text-shade-dark-default">
+          <Text weight="bold" className="text-shade-dark-default">
             使用中のインフラサービス
           </Text>
 
-          <Text variant="caption" className="text-shade-dark-default">
-            Google Cloud
-          </Text>
+          <Text className="text-shade-dark-default">Google Cloud</Text>
         </Row>
 
         <Row>
-          <Text bold variant="caption" className="text-shade-dark-default">
+          <Text weight="bold" className="text-shade-dark-default">
             停止の際の影響範囲
           </Text>
 
-          <Text variant="caption" className="text-shade-dark-default">
-            顧客がReckoner上で取引が出来ない
-          </Text>
+          <Text className="text-shade-dark-default">顧客がReckoner上で取引が出来ない</Text>
         </Row>
 
         <Row>
-          <Text bold variant="caption" className="text-shade-dark-default">
+          <Text weight="bold" className="text-shade-dark-default">
             構成図リンク
           </Text>
 
-          <Text variant="caption" className="text-shade-dark-default">
-            https://3-shake.com
-          </Text>
+          <Text className="text-shade-dark-default">https://3-shake.com</Text>
         </Row>
 
         <Row>
-          <Text bold variant="caption" className="text-shade-dark-default">
+          <Text weight="bold" className="text-shade-dark-default">
             トラフィック·ピーク時間帯
           </Text>
 
-          <Text variant="caption" className="text-shade-dark-default">
-            00:00 ~ 24:00
-          </Text>
+          <Text className="text-shade-dark-default">00:00 ~ 24:00</Text>
         </Row>
       </SkeletonX>
     </div>

--- a/packages/for-ui/src/skeleton/Skeleton.tsx
+++ b/packages/for-ui/src/skeleton/Skeleton.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import { FC, ReactNode, Children, isValidElement, cloneElement, Fragment } from 'react';
 import MuiSkeleton, { SkeletonProps as MuiSkeletonProps } from '@mui/material/Skeleton';
+import { fsx } from '../system/fsx';
 
 export type SkeletonProps = MuiSkeletonProps & {
   loading?: boolean;
@@ -7,58 +8,61 @@ export type SkeletonProps = MuiSkeletonProps & {
   count?: number;
 };
 
-export const Skeleton: React.FC<SkeletonProps> = ({ loading = false, count = 1, className, children, ...rest }) => {
+export const Skeleton: FC<SkeletonProps> = ({ loading = false, count = 1, className, children, ...rest }) => {
   if (loading) {
     return (
       <>
         {[...Array(count)].map((_, idx) => (
-          <MuiSkeleton className={className} {...rest} key={idx}>
-            {React.Children.count(children) > 0 && React.Children.toArray(children)[0]}
+          <MuiSkeleton className={fsx(`bg-shade-medium-disabled`, className)} {...rest} key={idx}>
+            {Children.count(children) > 0 && Children.toArray(children)[0]}
           </MuiSkeleton>
         ))}
       </>
     );
   }
-
-  return children as React.ReactElement;
+  if (isValidElement(children)) {
+    return children;
+  }
+  return <Fragment>{children}</Fragment>;
 };
 
-const recursiveChildren = (children: React.ReactNode, empty: React.ReactNode): React.ReactNode => {
+const recursiveChildren = (children: ReactNode, empty: ReactNode): ReactNode => {
   if (!children) return <></>;
 
-  return React.Children.map(children, (child: React.ReactNode) => {
-    if (!React.isValidElement<unknown>(child)) {
+  return Children.map(children, (child: ReactNode) => {
+    if (!isValidElement<unknown>(child)) {
       return child;
     }
 
-    if (!React.isValidElement<unknown>(empty)) {
+    if (!isValidElement<unknown>(empty)) {
       return empty;
     }
 
-    if (React.Children.count(child.props.children) > 1) {
+    if (Children.count(child.props.children) > 1) {
       return recursiveChildren(child.props.children, empty);
     }
-    if (React.Children.count(child.props.children) === 0) {
-      return <MuiSkeleton>{React.cloneElement(empty, empty.props)}</MuiSkeleton>;
+    if (Children.count(child.props.children) === 0) {
+      return <MuiSkeleton className={fsx(`bg-shade-medium-disabled`)}>{cloneElement(empty, empty.props)}</MuiSkeleton>;
     }
-    return <MuiSkeleton>{React.cloneElement(child, child.props)}</MuiSkeleton>;
+    return <MuiSkeleton className={fsx(`bg-shade-medium-disabled`)}>{cloneElement(child, child.props)}</MuiSkeleton>;
   });
 };
 
 type SkeletonXProps = MuiSkeletonProps & {
   loading?: boolean;
-  empty?: React.ReactNode;
+  empty?: ReactNode;
 };
 
-export const SkeletonX: React.FC<SkeletonXProps> = ({
+export const SkeletonX: FC<SkeletonXProps> = ({
   loading = false,
-  empty = <div>xxxxxxxxxxxxxxx</div>,
+  empty = <div aria-hidden>xxxxxxxxxxxxxxx</div>,
   children,
 }) => {
   if (loading) {
-    const childs = recursiveChildren(children, empty);
-
-    return <>{childs}</>;
+    return <Fragment>{recursiveChildren(children, empty)}</Fragment>;
   }
-  return children as React.ReactElement;
+  if (isValidElement(children)) {
+    return children;
+  }
+  return <Fragment>{children}</Fragment>;
 };


### PR DESCRIPTION
## チケット

- Close #1011 

## 実装内容

- Skelentonがchildrenによるundefinedやstringを返してエラーになっていた部分を修正
  - 型的に `as` のキャストで潰されていた部分を修正
  - childrenをrequiredにすることもできましたが、もとの実装の意図的にoptioinalでいいのかなと考えoptionalの際もloadingがtrueであればとりあえずskeletonを出すようになっています
- 色を `shade-background-medium-disabled` の正しい色に変更
- アクセシビリティ対応

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|    <img width="1410" alt="image" src="https://user-images.githubusercontent.com/8467289/219287789-3a18be4b-be9f-4ce5-ae3f-3709ea196b88.png">    |   <img width="1406" alt="image" src="https://user-images.githubusercontent.com/8467289/219287746-3fc19ba4-eefb-4cda-bf39-39368cb95d9d.png">     |

## 相談内容(あれば)

-
