### PR TITLE
fix(Select): dividerの追加とオプションが無いときの表示を修正

### DIFF
--- a/.changeset/ten-flies-build.md
+++ b/.changeset/ten-flies-build.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": minor
+---
+
+fix(Select): dividerの追加とオプションが無いときの表示を修正

--- a/packages/for-ui/src/menu/MenuList.tsx
+++ b/packages/for-ui/src/menu/MenuList.tsx
@@ -1,8 +1,29 @@
-import { forwardRef } from 'react';
-import MuiMenuList, { MenuListProps } from '@mui/material/MenuList';
+import { forwardRef, ElementType, Ref } from 'react';
+import MuiMenuList, { MenuListProps as MuiMenuListProps } from '@mui/material/MenuList';
 import { fsx } from '../system/fsx';
 import { style } from './style';
 
-export const MenuList = forwardRef<HTMLUListElement, MenuListProps>(({ className, ...rest }, ref) => (
-  <MuiMenuList ref={ref} className={fsx(style, className)} {...rest} />
-));
+export type MenuListProps<P extends ElementType = 'ul'> = MuiMenuListProps<P> & {
+  /**
+   * レンダリングするコンポーネントを指定 (例: h1, p, strong)
+   * @default span
+   */
+  as?: P;
+
+  ref?: Ref<P | null>;
+};
+
+const _MenuList = <P extends ElementType = 'ul'>({
+  as,
+  className,
+  _ref,
+  ...rest
+}: MenuListProps<P> & {
+  _ref: Ref<P | null | unknown>;
+}) => <MuiMenuList component={as || 'ul'} inputRef={_ref} className={fsx(style, className)} {...rest} />;
+
+export const MenuList = forwardRef((props, ref) => <_MenuList _ref={ref} {...props} />) as unknown as <
+  P extends ElementType = 'ul'
+>(
+  props: MenuListProps<P>
+) => JSX.Element;

--- a/packages/for-ui/src/select/Select.stories.tsx
+++ b/packages/for-ui/src/select/Select.stories.tsx
@@ -539,3 +539,5 @@ export const DisableFilter: Story = () => {
     </form>
   );
 };
+
+export const NoData = () => <Select name="hello" open options={[]} />;

--- a/packages/for-ui/src/select/Select.tsx
+++ b/packages/for-ui/src/select/Select.tsx
@@ -8,6 +8,7 @@ import { MdCheck, MdExpandMore } from 'react-icons/md';
 import { Chip } from '../chip';
 import { MenuItem, MenuList } from '../menu';
 import { TextField } from '../textField';
+import { Text } from '../text';
 
 export type SelectOption = {
   label: string;
@@ -52,7 +53,7 @@ const _Select = <
   disabled = false,
   disableFilter = false,
   inputRef,
-  noOptionsText = 'データが見つかりません',
+  noOptionsText = '選択肢がありません',
   className,
   ...rest
 }: AutocompleteProps<Value, Multiple, FreeSolo> & {
@@ -65,6 +66,7 @@ const _Select = <
     disableClearable
     autoHighlight
     clearOnBlur
+    openOnFocus
     disabled={disabled}
     includeInputInList
     handleHomeEndKeys
@@ -72,12 +74,22 @@ const _Select = <
     freeSolo={freeSolo}
     options={options}
     onChange={onChange}
-    PaperComponent={MenuList}
+    PaperComponent={(props) => <MenuList as="div" {...props} />}
+    ListboxComponent={(props) => <ul {...props} className={fsx(`p-0`)} />}
     isOptionEqualToValue={(option, v) =>
       typeof option === 'string' ? option === v : option.inputValue === v.inputValue
     }
-    noOptionsText={noOptionsText}
+    noOptionsText={
+      <Text typeface="sansSerif" size="r" className={fsx(`flex py-1 px-4 text-shade-medium-default`)}>
+        {noOptionsText}
+      </Text>
+    }
     popupIcon={<MdExpandMore size={24} />}
+    componentsProps={{
+      popupIndicator: {
+        disableRipple: true,
+      },
+    }}
     filterOptions={(options, params) => {
       const filtered = createFilterOptions<Value>()(options, params);
       const { inputValue } = params;
@@ -113,15 +125,6 @@ const _Select = <
       // Regular option
       return option.inputValue;
     }}
-    renderTags={(values, getTagProps) => (
-      <Fragment>
-        {values.map((option, index) => {
-          const tagProps = getTagProps({ index });
-          const label = typeof option === 'string' ? option : option.label;
-          return <Chip {...tagProps} key={tagProps.key} label={label} />;
-        })}
-      </Fragment>
-    )}
     renderOption={(props, option, { selected }) => {
       const label = typeof option === 'string' ? option : option.label;
       return (
@@ -135,21 +138,38 @@ const _Select = <
         </MenuItem>
       );
     }}
+    renderTags={(values, getTagProps) => (
+      <Fragment>
+        {values.map((option, index) => {
+          const tagProps = getTagProps({ index });
+          const label = typeof option === 'string' ? option : option.label;
+          return <Chip {...tagProps} key={tagProps.key} label={label} />;
+        })}
+      </Fragment>
+    )}
     classes={{
       root: fsx(`bg-shade-white-default w-full p-0`, className),
-      paper: fsx(`min-w-min p-0`),
+      paper: fsx(`min-w-min`),
       inputRoot: fsx([
         `group bg-shade-white-default text-shade-light-default p-0 antialiased`,
         disableFilter && `cursor-pointer`,
       ]),
+      noOptions: fsx(`p-0`),
       input: fsx([
-        `text-r text-shade-dark-default placeholder:text-shade-light-default h-auto py-2.5 px-3 font-sans placeholder:opacity-100 focus:shadow-none`,
+        `text-r text-shade-dark-default placeholder:text-shade-light-default h-auto py-2.5 px-3 pr-0 font-sans placeholder:opacity-100 focus:shadow-none`,
         disableFilter && `cursor-pointer caret-transparent`,
       ]),
       inputFocused: fsx(`border-primary-medium-active`),
       focused: fsx(`[&_svg]:!icon-shade-medium-active`),
       tag: fsx(`bg-shade-light-default [&.MuiChip-deleteIcon]:text-shade-dark-default border-none`),
-      endAdornment: fsx(`[&_svg]:icon-shade-medium-default`),
+      endAdornment: fsx([
+        `static flex [&_svg]:icon-shade-dark-default border-x border-shade-light-default`,
+        {
+          large: `px-2`,
+          medium: `px-1`,
+        }[size],
+      ]),
+      popupIndicator: fsx(`p-0 m-0`),
     }}
     renderInput={(params) => {
       return (


### PR DESCRIPTION
## チケット

- Close #1010 

## 実装内容

- Dividerの追加
  <img width="373" alt="image" src="https://user-images.githubusercontent.com/8467289/220056059-b1b0e177-603a-452e-b38a-690d721340b2.png">
- オプションがないときの表示を修正
  <img width="463" alt="image" src="https://user-images.githubusercontent.com/8467289/220056554-f85b7e18-ce48-4aed-bea3-7d81ca6973f9.png">
  - ulの直下にdivとなってしまっていたので、MenuListにas propsをつけて対応
    - 本来なら `noOptionsText` を表示するコンポーネントを作らせてほしいができないのでこの対応になった

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|    <img width="1409" alt="image" src="https://user-images.githubusercontent.com/8467289/220056753-7d9e3340-16e6-4eff-9e2a-1368e7d52dfe.png">    |   <img width="1407" alt="image" src="https://user-images.githubusercontent.com/8467289/220056675-750cd4ba-dd56-44c5-9c41-fff6ed33ee91.png">     |

## 相談内容(あれば)

- #1044 のあとにコンフリクトをなおして入れます
