### PR TITLE
fix(TextArea): size propsの追加とsize=mediumの追加

### DIFF
--- a/.changeset/bright-peaches-fail.md
+++ b/.changeset/bright-peaches-fail.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": minor
+---
+
+fix(TextArea): size propsの追加とsize=mediumの追加

--- a/packages/for-ui/src/textArea/TextArea.stories.tsx
+++ b/packages/for-ui/src/textArea/TextArea.stories.tsx
@@ -15,6 +15,7 @@ export default {
 
 export const Playground = {
   args: {
+    label: '',
     placeholder: '',
   },
 };

--- a/packages/for-ui/src/textArea/TextArea.stories.tsx
+++ b/packages/for-ui/src/textArea/TextArea.stories.tsx
@@ -13,6 +13,12 @@ export default {
   component: TextArea,
 } as Meta;
 
+export const Playground = {
+  args: {
+    placeholder: '',
+  },
+};
+
 type FieldValue = {
   email: string;
   password: string;
@@ -117,18 +123,4 @@ export const Default = (): JSX.Element => {
       <Button type="submit">登録する</Button>
     </form>
   );
-};
-
-export const Playground = {
-  args: {
-    rows: undefined,
-    minRows: undefined,
-    maxRows: undefined,
-    disabled: undefined,
-    placeholder: '',
-    error: undefined,
-    defaultValue: undefined,
-    value: undefined,
-    className: undefined,
-  },
 };

--- a/packages/for-ui/src/textArea/TextArea.tsx
+++ b/packages/for-ui/src/textArea/TextArea.tsx
@@ -31,6 +31,14 @@ export type TextAreaProps = Omit<TextareaAutosizeProps, 'disabled' | 'className'
    */
   label?: ReactNode;
 
+  /**
+   * サイズを指定
+   * 
+   * @default large
+   */
+  size?: 'large' | 'medium';
+
+
   className?: string;
 } & (
     | {
@@ -80,7 +88,7 @@ export type TextAreaProps = Omit<TextareaAutosizeProps, 'disabled' | 'className'
   );
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  ({ className, minRows, maxRows, rows, error, disabled, helperText, label, required, ...props }, ref) => {
+  ({ className, size = 'large', minRows, maxRows, rows, error, disabled, helperText, label, required, ...props }, ref) => {
     return (
       <div className={fsx(`w-full flex flex-col gap-1`, className)}>
         <Text as="label" className={fsx(`flex flex-col gap-1`)}>
@@ -104,6 +112,10 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
             maxRows={rows || maxRows}
             className={fsx([
               `w-full bg-shade-white-default ring-shade-medium-default ring-inset ring-1 text-r text-shade-dark-default placeholder:text-shade-light-default rounded h-auto py-2.5 px-3 font-sans font-normal placeholder:opacity-100  focus-visible:outline-none focus-visible:ring-primary-medium-active focus-visible:ring-2`,
+              {
+                large: `py-2 px-4`,
+                medium: `py-1 px-2`,
+              }[size],
               error && `ring-negative-medium-default focus-visible:ring-negative-medium-default`,
               disabled &&
                 `bg-shade-white-disabled ring-shade-medium-disabled text-shade-dark-disabled placeholder:text-shade-light-disabled cursor-not-allowed`,

--- a/packages/for-ui/src/textArea/TextArea.tsx
+++ b/packages/for-ui/src/textArea/TextArea.tsx
@@ -33,11 +33,10 @@ export type TextAreaProps = Omit<TextareaAutosizeProps, 'disabled' | 'className'
 
   /**
    * サイズを指定
-   * 
+   *
    * @default large
    */
   size?: 'large' | 'medium';
-
 
   className?: string;
 } & (
@@ -88,7 +87,10 @@ export type TextAreaProps = Omit<TextareaAutosizeProps, 'disabled' | 'className'
   );
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  ({ className, size = 'large', minRows, maxRows, rows, error, disabled, helperText, label, required, ...props }, ref) => {
+  (
+    { className, size = 'large', minRows, maxRows, rows, error, disabled, helperText, label, required, ...props },
+    ref
+  ) => {
     return (
       <div className={fsx(`w-full flex flex-col gap-1`, className)}>
         <Text as="label" className={fsx(`flex flex-col gap-1`)}>
@@ -111,7 +113,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
             minRows={rows || minRows}
             maxRows={rows || maxRows}
             className={fsx([
-              `w-full bg-shade-white-default ring-shade-medium-default ring-inset ring-1 text-r text-shade-dark-default placeholder:text-shade-light-default rounded h-auto py-2.5 px-3 font-sans font-normal placeholder:opacity-100  focus-visible:outline-none focus-visible:ring-primary-medium-active focus-visible:ring-2`,
+              `w-full bg-shade-white-default ring-shade-medium-default ring-inset ring-1 text-r text-shade-dark-default placeholder:text-shade-light-default rounded h-auto font-sans font-normal placeholder:opacity-100  focus-visible:outline-none focus-visible:ring-primary-medium-active focus-visible:ring-2`,
               {
                 large: `py-2 px-4`,
                 medium: `py-1 px-2`,


### PR DESCRIPTION
## チケット

- Close #869 

## 実装内容

- TextAreaにsize propsを追加
- TextAreaにsize=mediumを追加
- TextAreaのsize=largeのpaddingを最新のものに修正

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|    新規につきなし    |   <img width="1408" alt="image" src="https://user-images.githubusercontent.com/8467289/221120593-3742ed69-4778-42d3-8316-b217d505c3dc.png">     |

## 相談内容(あれば)

-
