### PR TITLE
fix(Select): disabledのときにexpand moreボタンをdisabled色に修正

### DIFF
--- a/.changeset/quiet-maps-rhyme.md
+++ b/.changeset/quiet-maps-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(Select): disabledのときにexpand moreボタンをdisabled色に修正

--- a/packages/for-ui/src/select/Select.tsx
+++ b/packages/for-ui/src/select/Select.tsx
@@ -156,7 +156,7 @@ const _Select = <
       input: fsx([`min-w-20`, disableFilter && `cursor-pointer caret-transparent`]),
       noOptions: fsx(`p-0`),
       endAdornment: fsx([
-        `static flex [&_svg]:icon-shade-dark-default border-x border-shade-light-default`,
+        `static flex [&_svg]:icon-shade-dark-default border-x border-shade-light-default [input:disabled+&_svg]:icon-shade-dark-disabled`,
         {
           large: `px-2`,
           medium: `px-1`,


### PR DESCRIPTION
## チケット

- Close #1082 

## 実装内容

- disabledのときにexpand moreボタンをdisabled色に修正

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|    <img width="1154" alt="image" src="https://user-images.githubusercontent.com/8467289/222638244-4211d6f1-1445-4469-869f-ed79c55ba57f.png">    |       <img width="1150" alt="image" src="https://user-images.githubusercontent.com/8467289/222638280-01559856-18b2-4e8f-a271-76bb0d700984.png"> |

## 相談内容(あれば)

-
