### PR TITLE
fix(TextField, TeatArea): labelのクリックできるエリアを文字の上だけになるよう修正

### DIFF
--- a/.changeset/tasty-camels-talk.md
+++ b/.changeset/tasty-camels-talk.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(TextField, TeatArea): labelのクリックできるエリアを文字の上だけになるよう修正

--- a/packages/for-ui/src/textArea/TextArea.tsx
+++ b/packages/for-ui/src/textArea/TextArea.tsx
@@ -88,11 +88,24 @@ export type TextAreaProps = Omit<TextareaAutosizeProps, 'disabled' | 'className'
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   (
-    { className, size = 'large', minRows, maxRows, rows, error, disabled, helperText, label, required, id: passedId, ...props },
+    {
+      className,
+      size = 'large',
+      minRows,
+      maxRows,
+      rows,
+      error,
+      disabled,
+      helperText,
+      label,
+      required,
+      id: passedId,
+      ...props
+    },
     ref,
   ) => {
-    const innerId = useId()
-    const id = passedId || innerId
+    const innerId = useId();
+    const id = passedId || innerId;
     return (
       <div className={fsx(`flex w-full flex-col gap-1`, className)}>
         <fieldset className={fsx(`contents`)}>
@@ -102,14 +115,13 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
                 <TextDefaultStyler
                   content={label}
                   defaultRenderer={({ children, ...rest }) => (
-                    <Text
-                      weight="bold"
-                      size="s"
-                      className={fsx(`text-shade-medium-default`)}
-                      {...rest}
-                    >
+                    <Text weight="bold" size="s" className={fsx(`text-shade-medium-default`)} {...rest}>
                       {children}
-                      {required && <Text as="abbr" title="必須" className="text-negative-dark-default no-underline">*</Text>}
+                      {required && (
+                        <Text as="abbr" title="必須" className="text-negative-dark-default no-underline">
+                          *
+                        </Text>
+                      )}
                     </Text>
                   )}
                 />

--- a/packages/for-ui/src/textArea/TextArea.tsx
+++ b/packages/for-ui/src/textArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode } from 'react';
+import { forwardRef, ReactNode, useId } from 'react';
 import TextareaAutosize, { TextareaAutosizeProps } from '@mui/base/TextareaAutosize';
 import { fsx } from '../system/fsx';
 import { TextDefaultStyler } from '../system/TextDefaultStyler';
@@ -88,27 +88,37 @@ export type TextAreaProps = Omit<TextareaAutosizeProps, 'disabled' | 'className'
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   (
-    { className, size = 'large', minRows, maxRows, rows, error, disabled, helperText, label, required, ...props },
+    { className, size = 'large', minRows, maxRows, rows, error, disabled, helperText, label, required, id: passedId, ...props },
     ref,
   ) => {
+    const innerId = useId()
+    const id = passedId || innerId
     return (
       <div className={fsx(`flex w-full flex-col gap-1`, className)}>
-        <Text as="label" className={fsx(`flex flex-col gap-1`)}>
-          <TextDefaultStyler
-            content={label}
-            defaultRenderer={({ children, ...props }) => (
-              <Text {...props} size="s" weight="bold" className={fsx(`text-shade-medium-default`)}>
-                {children}
-                {children && required && (
-                  <Text className={fsx(`text-negative-dark-default`)} weight="regular">
-                    *
-                  </Text>
-                )}
+        <fieldset className={fsx(`contents`)}>
+          {label && (
+            <legend className={fsx(`contents`)}>
+              <Text as="label" htmlFor={id} className="w-fit">
+                <TextDefaultStyler
+                  content={label}
+                  defaultRenderer={({ children, ...rest }) => (
+                    <Text
+                      weight="bold"
+                      size="s"
+                      className={fsx(`text-shade-medium-default`)}
+                      {...rest}
+                    >
+                      {children}
+                      {required && <Text as="abbr" title="必須" className="text-negative-dark-default no-underline">*</Text>}
+                    </Text>
+                  )}
+                />
               </Text>
-            )}
-          />
+            </legend>
+          )}
           <TextareaAutosize
             {...props}
+            id={id}
             disabled={disabled}
             minRows={rows || minRows}
             maxRows={rows || maxRows}
@@ -124,7 +134,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
             ])}
             ref={ref}
           />
-        </Text>
+        </fieldset>
         <TextDefaultStyler
           content={helperText}
           defaultRenderer={(props) => (

--- a/packages/for-ui/src/textField/TextField.stories.tsx
+++ b/packages/for-ui/src/textField/TextField.stories.tsx
@@ -36,6 +36,7 @@ export const Playground = {
     label: 'ラベル',
     required: false,
     disabled: false,
+    error: false,
   },
 };
 

--- a/packages/for-ui/src/textField/TextField.tsx
+++ b/packages/for-ui/src/textField/TextField.tsx
@@ -135,14 +135,13 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
                 <TextDefaultStyler
                   content={label}
                   defaultRenderer={({ children, ...rest }) => (
-                    <Text
-                      weight="bold"
-                      size="s"
-                      className={fsx(`text-shade-medium-default`)}
-                      {...rest}
-                    >
+                    <Text weight="bold" size="s" className={fsx(`text-shade-medium-default`)} {...rest}>
                       {children}
-                      {required && <Text as="abbr" title="必須" className="text-negative-dark-default no-underline">*</Text>}
+                      {required && (
+                        <Text as="abbr" title="必須" className="text-negative-dark-default no-underline">
+                          *
+                        </Text>
+                      )}
                     </Text>
                   )}
                 />

--- a/packages/for-ui/src/textField/TextField.tsx
+++ b/packages/for-ui/src/textField/TextField.tsx
@@ -131,22 +131,22 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         <fieldset className={fsx(`contents`)}>
           {label && (
             <legend className={fsx(`contents`)}>
-              <TextDefaultStyler
-                content={label}
-                defaultRenderer={({ children, ...rest }) => (
-                  <Text
-                    as="label"
-                    htmlFor={id}
-                    weight="bold"
-                    size="s"
-                    className={fsx(`text-shade-medium-default`)}
-                    {...rest}
-                  >
-                    {children}
-                    {required && <Text className="text-negative-dark-default">*</Text>}
-                  </Text>
-                )}
-              />
+              <Text as="label" htmlFor={id} className="w-fit">
+                <TextDefaultStyler
+                  content={label}
+                  defaultRenderer={({ children, ...rest }) => (
+                    <Text
+                      weight="bold"
+                      size="s"
+                      className={fsx(`text-shade-medium-default`)}
+                      {...rest}
+                    >
+                      {children}
+                      {required && <Text as="abbr" title="必須" className="text-negative-dark-default no-underline">*</Text>}
+                    </Text>
+                  )}
+                />
+              </Text>
             </legend>
           )}
           <OutlinedInput


### PR DESCRIPTION
## チケット

- Close #1101 

## 実装内容

- TextField, TextArea: labelをw-fitにしてクリックしてフォーカスになるエリアを文字の上だけに限定
- アクセシビリティ対応の一貫として必須表示のアスタリスクをabbr要素にした
  - https://www.w3.org/TR/WCAG20-TECHS/H90.html によると省略形を使うときはページのどこかに `* は必須を示す` という趣旨の文言が必要なため、やはり必須を文字で書いたラベルのほうが好ましい

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

- Selectで同様の問題が解決できていません。内部的にはTextFieldなので問題なさそうなのですが、現在原因特定中です。
