### PR TITLE
chore: Renovateのgroup:allNonMajorを外す

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base", "group:allNonMajor", ":timezone(Asia/Tokyo)"],
+  "extends": ["config:base", ":timezone(Asia/Tokyo)"],
   "schedule": ["after 10:30 before 18:00 every weekday except after 13:00 before 14:00"],
   "useBaseBranchConfig": "merge"
 }


### PR DESCRIPTION
## チケット

- Close #1125 

## 実装内容

- renovate.jsonの`group:allNonMajor`を外した
  - アップグレード作業が終わり次第このPRをrevertすると戻せるはずです

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
