### PR TITLE
chore: npm v7以降を使うよう制約を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "eslint-plugin-promise": "^6.0.0"
-      },
       "devDependencies": {
         "@changesets/changelog-github": "0.4.8",
         "@changesets/cli": "2.26.0",
@@ -25,7 +22,8 @@
         "typescript": "4.9.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@4design/eslint-config": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "packages/*"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=14.0.0",
+    "npm": ">=7.0.0"
   },
   "scripts": {
     "build": "turbo run build",


### PR DESCRIPTION
## チケット

- Close #1150 

## 実装内容

- enginesにnpm v7以降を指定
  - 根拠等は #1150 を参照

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
