### PR TITLE
fix(system): ReactNodeとisValidElementのReactElement型の差異を解消

### DIFF
--- a/.changeset/modern-donkeys-jump.md
+++ b/.changeset/modern-donkeys-jump.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(system): ReactNodeとisValidElementのReactElement型の差異を解消

--- a/packages/for-ui/src/system/TextDefaultStyler.tsx
+++ b/packages/for-ui/src/system/TextDefaultStyler.tsx
@@ -3,7 +3,7 @@ import { FC, isValidElement, ReactElement, ReactNode } from 'react';
 export type TextDefaultStylerProps = {
   /**
    * 適用されるラベル等を指定
-   * 
+   *
    * contentがstringやnumberなどReactElementではない場合にdefaultRendererを用いて描画されます。
    * contentがReactElementの場合はdefaultRendererを用いずにそのまま描画されます。
    */

--- a/packages/for-ui/src/system/TextDefaultStyler.tsx
+++ b/packages/for-ui/src/system/TextDefaultStyler.tsx
@@ -1,7 +1,17 @@
 import { FC, isValidElement, ReactElement, ReactNode } from 'react';
 
 export type TextDefaultStylerProps = {
+  /**
+   * 適用されるラベル等を指定
+   * 
+   * contentがstringやnumberなどReactElementではない場合にdefaultRendererを用いて描画されます。
+   * contentがReactElementの場合はdefaultRendererを用いずにそのまま描画されます。
+   */
   content: ReactNode;
+
+  /**
+   * contentがReactElementではない場合に描画に用いるコンポーネントを指定
+   */
   defaultRenderer: FC<{ children: Exclude<ReactNode, ReactElement> }>;
 };
 
@@ -9,7 +19,9 @@ export const TextDefaultStyler: FC<TextDefaultStylerProps> = ({ content, default
   if (!content) {
     return null;
   }
-  if (isValidElement(content)) {
+  // TODO: To eliminate the gap, `any` is used. (ReactNode's ReactElement is ReactElement<any>, but isValidElement's returned ReactElement is ReactElement<unknown>)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (isValidElement<any>(content)) {
     return content;
   }
   return <DefaultRenderer>{content}</DefaultRenderer>;


### PR DESCRIPTION
## チケット

- Close #1180 

## 実装内容

- ReactElementの型がReactNodeとisValidElementで異なり、TypeScript v5でエラーとなるため修正した
  - 参考 https://github.com/microsoft/TypeScript/issues/53178
  - anyを使うほかに解消する術がないためコメントを残した

## スクリーンショット

変更なし

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
