### PR TITLE
fix: React v17以下のサポートを終了

### DIFF
--- a/.changeset/sour-buckets-smash.md
+++ b/.changeset/sour-buckets-smash.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix: React v17以下のサポートを終了

--- a/package-lock.json
+++ b/package-lock.json
@@ -5333,11 +5333,14 @@
       }
     },
     "node_modules/@storybook/builder-webpack4/node_modules/watchpack/chokidar2": {
-      "version": "0.0.1",
+      "version": "2.0.0",
       "dev": true,
       "optional": true,
       "dependencies": {
         "chokidar": "^2.1.8"
+      },
+      "engines": {
+        "node": "<8.10.0"
       }
     },
     "node_modules/@storybook/builder-webpack4/node_modules/webpack": {
@@ -26674,8 +26677,8 @@
         "@mui/lab": ">=5.0.0-alpha.73",
         "@mui/material": ">=5.9.3",
         "@tanstack/react-table": ">=8.5.22",
-        "@types/react": ">=17.0.11",
-        "react": ">=17.0.2",
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0",
         "react-icons": ">=4.3.0",
         "tailwindcss": ">=3.0.0"
       }

--- a/packages/for-ui/package.json
+++ b/packages/for-ui/package.json
@@ -42,8 +42,8 @@
     "@mui/lab": ">=5.0.0-alpha.73",
     "@mui/material": ">=5.9.3",
     "@tanstack/react-table": ">=8.5.22",
-    "@types/react": ">=17.0.11",
-    "react": ">=17.0.2",
+    "@types/react": ">=18.0.0",
+    "react": ">=18.0.0",
     "react-icons": ">=4.3.0",
     "tailwindcss": ">=3.0.0"
   },


### PR DESCRIPTION
## チケット

- Close #1112 

## 実装内容

- peerDependenciesのreactと@types/reactのバージョンを18以上に修正

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
