### PR TITLE
fix: secondary-border-dark-default が抜けていたのを修正

### DIFF
--- a/.changeset/rotten-frogs-lick.md
+++ b/.changeset/rotten-frogs-lick.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix: secondary-border-dark-default が抜けていたのを修正

--- a/packages/for-ui/styles/forty.css
+++ b/packages/for-ui/styles/forty.css
@@ -108,6 +108,7 @@
   --secondary-background-dark-hover: var(--green-100);
   --secondary-background-light-default: var(--green-10);
   --secondary-background-light-hover: var(--green-20);
+  --secondary-border-dark-default: var(--green-90);
   --secondary-border-medium-default: var(--green-40);
   --secondary-border-light-default: var(--green-20);
   --secondary-icon-dark-default: var(--green-90);

--- a/packages/for-ui/tailwind.config.base.js
+++ b/packages/for-ui/tailwind.config.base.js
@@ -134,6 +134,9 @@ const colors = {
       },
     },
     border: {
+      dark: {
+        default: 'var(--secondary-border-dark-default)',
+      },
       medium: {
         default: 'var(--secondary-border-medium-default)',
       },


### PR DESCRIPTION
## チケット

- Close #1223 

## 実装内容

- secondary-border-dark-default が抜けていたのを修正
  - Figma側も修正

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
