### PR TITLE
fix: Tailwind CSSのクラス名の順序を修正

### DIFF
--- a/.changeset/chilly-rules-juggle.md
+++ b/.changeset/chilly-rules-juggle.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix: Tailwind CSSのクラス名の順序を修正

--- a/packages/for-ui/src/dropzone/Dropzone.tsx
+++ b/packages/for-ui/src/dropzone/Dropzone.tsx
@@ -28,14 +28,14 @@ export const Dropzone: React.FC<DropzoneProps> = ({
     <div
       {...getRootProps()}
       className={fsx([
-        'flex w-auto cursor-pointer flex-col flex-wrap justify-center py-3 px-5',
+        'flex w-auto cursor-pointer flex-col flex-wrap justify-center px-5 py-3',
         'border-shade-medium-default rounded border border-dashed',
         className,
       ])}
     >
       <input {...getInputProps()} />
 
-      <div className="text-shade-medium-default flex w-full flex-col items-center py-5 px-3">
+      <div className="text-shade-medium-default flex w-full flex-col items-center px-3 py-5">
         <MdFileUpload size={48} className="text-shade-light-default mb-3" />
         <Text size="s">{message}</Text>
       </div>

--- a/packages/for-ui/src/select/Select.tsx
+++ b/packages/for-ui/src/select/Select.tsx
@@ -75,7 +75,7 @@ const _Select = <
       typeof option === 'string' ? option === v : option.inputValue === v.inputValue
     }
     noOptionsText={
-      <Text typeface="sansSerif" size="r" className={fsx(`text-shade-medium-default flex py-1 px-4`)}>
+      <Text typeface="sansSerif" size="r" className={fsx(`text-shade-medium-default flex px-4 py-1`)}>
         {noOptionsText}
       </Text>
     }

--- a/packages/for-ui/src/stepper/Step.tsx
+++ b/packages/for-ui/src/stepper/Step.tsx
@@ -44,7 +44,7 @@ const Icon = (props: Partial<MuiStepIconProps>) => {
             : 'border-primary-dark-disabled bg-shade-white-disabled text-shade-dark-disabled',
         ])}
       >
-        <span className={fsx(['absolute top-2/4 left-2/4 -translate-x-2/4 -translate-y-2/4'])}>{icon}</span>
+        <span className={fsx(['absolute left-2/4 top-2/4 -translate-x-2/4 -translate-y-2/4'])}>{icon}</span>
       </span>
     </>
   );

--- a/packages/for-ui/src/stepper/Stepper.tsx
+++ b/packages/for-ui/src/stepper/Stepper.tsx
@@ -17,7 +17,7 @@ export const Stepper = forwardRef<HTMLDivElement, StepperProps>(
         connector={
           <StepConnector
             classes={{
-              root: fsx('right-[calc(50%+1rem)] left-[calc(-50%+1rem)] top-6 px-0', className),
+              root: fsx('left-[calc(-50%+1rem)] right-[calc(50%+1rem)] top-6 px-0', className),
               line: fsx('border-t-2'),
             }}
             sx={{

--- a/packages/for-ui/src/tab/Tab.tsx
+++ b/packages/for-ui/src/tab/Tab.tsx
@@ -11,7 +11,7 @@ export const Tab: FC<TabProps> = ({ minWidth, tabIndex, className, badge, ...res
   <MuiTab
     disableRipple
     className={fsx(
-      `text-shade-dark-default hover:bg-shade-white-hover text-r [&:focus-visible]:bg-shade-white-active disabled:text-shade-dark-disabled flex min-h-min min-w-min gap-1 border-y-2 border-solid border-transparent py-1.5 px-4 normal-case opacity-100 transition-all duration-100 disabled:cursor-not-allowed`,
+      `text-shade-dark-default hover:bg-shade-white-hover text-r [&:focus-visible]:bg-shade-white-active disabled:text-shade-dark-disabled flex min-h-min min-w-min gap-1 border-y-2 border-solid border-transparent px-4 py-1.5 normal-case opacity-100 transition-all duration-100 disabled:cursor-not-allowed`,
       className,
     )}
     tabIndex={tabIndex ?? 0}

--- a/packages/for-ui/src/table/TableCell.tsx
+++ b/packages/for-ui/src/table/TableCell.tsx
@@ -13,7 +13,7 @@ export const TableCell = ({ component = 'td', className, children, ...rest }: Ta
       {component === 'td' ? (
         <td
           className={fsx([
-            'border-shade-light-default text-shade-dark-default text-r border-b py-2 px-3 text-left font-normal',
+            'border-shade-light-default text-shade-dark-default text-r border-b px-3 py-2 text-left font-normal',
             className,
           ])}
           {...rest}
@@ -23,7 +23,7 @@ export const TableCell = ({ component = 'td', className, children, ...rest }: Ta
       ) : (
         <th
           className={fsx([
-            'border-shade-light-default text-shade-dark-default text-r border-b py-2 px-3 text-left font-normal',
+            'border-shade-light-default text-shade-dark-default text-r border-b px-3 py-2 text-left font-normal',
             className,
           ])}
           {...rest}


### PR DESCRIPTION
## チケット

- Close #1228 

## 実装内容

- npm run fmt によるTailwind CSSのクラス名の順序のlint警告を解消

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
