### PR TITLE
fix(Chip): `as` propsを追加

### DIFF
--- a/packages/for-ui/src/chip/Chip.tsx
+++ b/packages/for-ui/src/chip/Chip.tsx
@@ -1,49 +1,81 @@
-import { ComponentPropsWithoutRef, FC, MouseEvent, ReactNode } from 'react';
+import { ElementType, forwardRef, MouseEvent, ReactNode } from 'react';
+import { ComponentProps, ElementTypeToHTMLElement, Ref } from '../system/polyComponent';
 import { FullChip } from './FullChip';
 import { LimitedChip } from './LimitedChip';
 
-export type ChipProps = Omit<ComponentPropsWithoutRef<'button'>, 'color'> & {
-  /**
-   * ユーザーに提示したい意図 (e.g. エラーならばnegative) を指定
-   *
-   * @default shade
-   */
-  intention?: 'shade' | 'primary' | 'secondary' | 'positive' | 'negative' | 'notice' | 'informative';
+export type ChipProps<As extends ElementType = 'button'> = ComponentProps<
+  {
+    /**
+     * ユーザーに提示したい意図 (e.g. エラーならばnegative) を指定
+     *
+     * @default 'shade'
+     */
+    intention?: 'shade' | 'primary' | 'secondary' | 'positive' | 'negative' | 'notice' | 'informative';
 
-  /**
-   * ラベルを指定
-   */
-  label: string;
+    /**
+     * ラベルを指定
+     */
+    label: string;
 
-  /**
-   * クリックできる範囲を指定
-   *
-   * 通常、limitedは削除可能なChipに使い、他の用途ではなるべくfullを使うことが推奨されます。
-   *
-   * @default full
-   */
-  clickableArea?: 'full' | 'limited';
+    /**
+     * クリックできる範囲を指定
+     *
+     * 通常、limitedは削除可能なChipに使い、他の用途ではなるべくfullを使うことが推奨されます。
+     *
+     * @default 'full'
+     */
+    clickableArea?: 'full' | 'limited';
 
-  /**
-   * アイコンを指定
-   *
-   * clickableAreahがlimitedの場合、デフォルトのiconは (Xボタン) になります。
-   */
-  icon?: ReactNode;
+    /**
+     * アイコンを指定
+     *
+     * clickableAreahがlimitedの場合、デフォルトのiconは (Xボタン) になります。
+     */
+    icon?: ReactNode;
 
-  /**
-   * クリックしたときの動作を指定
-   *
-   * これは必須項目です。クリックできないものについてはBadgeの使用を検討してください。
-   * クリックできる範囲はclickableArea propsで指定してください。
-   */
-  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+    /**
+     * クリックしたときの動作を指定
+     *
+     * これは必須項目です。クリックできないものについてはBadgeの使用を検討してください。
+     * クリックできる範囲はclickableArea propsで指定してください。
+     */
+    onClick: (e: MouseEvent<ElementTypeToHTMLElement<As>>) => void;
 
-  className?: string;
-};
+    className?: string;
+  },
+  As
+>;
 
-export const Chip: FC<ChipProps> = ({ clickableArea = 'full', ...props }) =>
-  ({
-    full: <FullChip {...props} />,
-    limited: <LimitedChip {...props} />,
-  }[clickableArea]);
+type ChipComponent = <As extends ElementType = 'button'>(props: ChipProps<As>) => JSX.Element | null;
+
+export const Chip: ChipComponent = forwardRef(
+  <As extends ElementType = 'button'>({ clickableArea = 'full', ...props }: ChipProps<As>, ref?: Ref<As>) =>
+    ({
+      full: <FullChip<As> {...props} ref={ref} />,
+      limited: <LimitedChip<As> {...props} ref={ref} />,
+    }[clickableArea]),
+);
+
+////////////////////
+
+// const _Chip = <As extends ElementType = 'button'>({
+//   clickableArea = 'full',
+//   ...props
+// }: ChipPropsWithoutRef<As> & { _ref?: ComponentPropsWithRef<As>["ref"]; }): JSX.Element =>
+//   ({
+//     full: <FullChip<As> {...props} />,
+//     limited: <LimitedChip<As> {...props} />,
+//   }[clickableArea]);
+
+// export type ChipProps<As extends ElementType = 'button'> = ChipPropsWithoutRef<As> &
+// // {  ref?: Ref<As extends keyof HTMLElementTagNameMap ? HTMLElementTagNameMap[As] : As> };
+// RefAttributes<ComponentPropsWithRef<As>["ref"]>
+
+// export const Chip = forwardRef((props: ChipPropsWithoutRef<ElementType>, ref: ComponentPropsWithRef<ElementType>["ref"]) => (
+//   <_Chip {...props} _ref={ref} />
+// )) as <As extends ElementType = 'button'>(props: ChipProps<As>) => JSX.Element | null;
+
+// type ChipProps<As extends ElementType = 'button'> = PolymorphicComponentPropWithRef<
+//   As,
+//   ChipPropsWithoutRef
+// >

--- a/packages/for-ui/src/chip/FullChip.tsx
+++ b/packages/for-ui/src/chip/FullChip.tsx
@@ -1,66 +1,70 @@
-import { FC } from 'react';
+import { ElementType, forwardRef } from 'react';
 import { fsx } from '../system/fsx';
+import { Ref } from '../system/polyComponent';
 import { Text } from '../text';
 import { ChipProps } from './Chip';
 
-export const FullChip: FC<Omit<ChipProps, 'clickableArea'>> = ({
-  label,
-  icon,
-  intention = 'shade',
-  onClick,
-  className,
-  ...rest
-}) => (
-  <button
-    onClick={onClick}
-    className={fsx([
-      `shadow-attractive focus-visible:shadow-focused inline-flex h-fit w-fit flex-row items-center justify-center gap-1 break-keep rounded px-2 outline outline-1 -outline-offset-1`,
-      {
-        shade: `bg-shade-white-default outline-shade-medium-default hover:bg-shade-white-hover focus-visible:bg-shade-white-hover`,
-        primary: `bg-primary-light-default outline-primary-medium-default hover:bg-primary-light-hover focus-visible:bg-primary-light-hover`,
-        secondary: `bg-secondary-light-default outline-secondary-medium-default hover:bg-secondary-light-hover focus-visible:bg-secondary-light-hover`,
-        positive: `bg-positive-light-default outline-positive-medium-default hover:bg-positive-light-hover focus-visible:bg-positive-light-hover`,
-        negative: `bg-negative-light-default outline-negative-medium-default hover:bg-negative-light-hover focus-visible:bg-negative-light-hover`,
-        notice: `bg-notice-light-default outline-notice-medium-default hover:bg-notice-light-hover focus-visible:bg-notice-light-hover`,
-        informative: `bg-informative-light-default outline-informative-medium-default hover:bg-informative-light-hover focus-visible:bg-informative-light-hover`,
-      }[intention],
-      className,
-    ])}
-    {...rest}
-  >
-    {icon && (
-      <span
+type FullChipProps<As extends ElementType = 'button'> = Omit<ChipProps<As>, 'clickableArea'>;
+
+type FullChipComponent = <As extends ElementType = 'button'>(props: FullChipProps<As>) => JSX.Element | null;
+
+export const FullChip: FullChipComponent = forwardRef(
+  <As extends ElementType = 'button'>(props: FullChipProps<As>, ref: Ref<As>): JSX.Element => {
+    const { as, label, icon, intention = 'shade', className, ...rest } = props;
+    const Component: ElementType = as || 'button';
+    return (
+      <Component
         className={fsx([
-          `h-4 w-4 [&_svg]:h-full [&_svg]:w-full`,
+          `shadow-attractive focus-visible:shadow-focused inline-flex h-fit w-fit flex-row items-center justify-center gap-1 break-keep rounded px-2 outline outline-1 -outline-offset-1`,
           {
-            shade: `icon-shade-dark-default`,
-            primary: `icon-primary-dark-default`,
-            secondary: `icon-secondary-dark-default`,
-            positive: `icon-positive-dark-default`,
-            negative: `icon-negative-dark-default`,
-            notice: `icon-notice-dark-default`,
-            informative: `icon-informative-dark-default`,
+            shade: `bg-shade-white-default outline-shade-medium-default hover:bg-shade-white-hover focus-visible:bg-shade-white-hover`,
+            primary: `bg-primary-light-default outline-primary-medium-default hover:bg-primary-light-hover focus-visible:bg-primary-light-hover`,
+            secondary: `bg-secondary-light-default outline-secondary-medium-default hover:bg-secondary-light-hover focus-visible:bg-secondary-light-hover`,
+            positive: `bg-positive-light-default outline-positive-medium-default hover:bg-positive-light-hover focus-visible:bg-positive-light-hover`,
+            negative: `bg-negative-light-default outline-negative-medium-default hover:bg-negative-light-hover focus-visible:bg-negative-light-hover`,
+            notice: `bg-notice-light-default outline-notice-medium-default hover:bg-notice-light-hover focus-visible:bg-notice-light-hover`,
+            informative: `bg-informative-light-default outline-informative-medium-default hover:bg-informative-light-hover focus-visible:bg-informative-light-hover`,
           }[intention],
+          className,
         ])}
+        ref={ref}
+        {...rest}
       >
-        {icon}
-      </span>
-    )}
-    <Text
-      className={fsx([
-        `flex items-center`,
-        {
-          shade: `text-shade-dark-default`,
-          primary: `text-primary-dark-default`,
-          secondary: `text-secondary-dark-default`,
-          positive: `text-positive-dark-default`,
-          negative: `text-negative-dark-default`,
-          notice: `text-notice-dark-default`,
-          informative: `text-informative-dark-default`,
-        }[intention],
-      ])}
-    >
-      {label}
-    </Text>
-  </button>
+        {icon && (
+          <span
+            className={fsx([
+              `h-4 w-4 [&_svg]:h-full [&_svg]:w-full`,
+              {
+                shade: `icon-shade-dark-default`,
+                primary: `icon-primary-dark-default`,
+                secondary: `icon-secondary-dark-default`,
+                positive: `icon-positive-dark-default`,
+                negative: `icon-negative-dark-default`,
+                notice: `icon-notice-dark-default`,
+                informative: `icon-informative-dark-default`,
+              }[intention],
+            ])}
+          >
+            {icon}
+          </span>
+        )}
+        <Text
+          className={fsx([
+            `flex items-center`,
+            {
+              shade: `text-shade-dark-default`,
+              primary: `text-primary-dark-default`,
+              secondary: `text-secondary-dark-default`,
+              positive: `text-positive-dark-default`,
+              negative: `text-negative-dark-default`,
+              notice: `text-notice-dark-default`,
+              informative: `text-informative-dark-default`,
+            }[intention],
+          ])}
+        >
+          {label}
+        </Text>
+      </Component>
+    );
+  },
 );

--- a/packages/for-ui/src/chip/LimitedChip.tsx
+++ b/packages/for-ui/src/chip/LimitedChip.tsx
@@ -1,65 +1,71 @@
-import { FC } from 'react';
+import { ElementType, forwardRef } from 'react';
 import { MdClose } from 'react-icons/md';
 import { fsx } from '../system/fsx';
+import { Ref } from '../system/polyComponent';
 import { Text } from '../text';
 import { ChipProps } from './Chip';
 
-export const LimitedChip: FC<Omit<ChipProps, 'clickableArea'>> = ({
-  label,
-  icon = <MdClose />,
-  intention = 'shade',
-  onClick,
-  className,
-  ...rest
-}) => (
-  <span
-    className={fsx([
-      `shadow-attractive inline-flex h-fit w-fit flex-row items-center justify-center gap-1 break-keep rounded px-2 pr-0 outline outline-1 -outline-offset-1`,
-      {
-        shade: `bg-shade-white-default outline-shade-medium-default`,
-        primary: `bg-primary-light-default outline-primary-medium-default`,
-        secondary: `bg-secondary-light-default outline-secondary-medium-default`,
-        positive: `bg-positive-light-default outline-positive-medium-default`,
-        negative: `bg-negative-light-default outline-negative-medium-default`,
-        notice: `bg-notice-light-default outline-notice-medium-default`,
-        informative: `bg-informative-light-default outline-informative-medium-default`,
-      }[intention],
-      className,
-    ])}
-  >
-    <Text
-      className={fsx([
-        `flex items-center`,
-        {
-          shade: `text-shade-dark-default`,
-          primary: `text-primary-dark-default`,
-          secondary: `text-secondary-dark-default`,
-          positive: `text-positive-dark-default`,
-          negative: `text-negative-dark-default`,
-          notice: `text-notice-dark-default`,
-          informative: `text-informative-dark-default`,
-        }[intention],
-      ])}
-    >
-      {label}
-    </Text>
-    <button
-      onClick={onClick}
-      className={fsx([
-        `focus-visible:shadow-focused flex h-6 w-6 flex-row items-start rounded-r p-1 outline outline-1 -outline-offset-1 [&_svg]:h-full [&_svg]:w-full`,
-        {
-          shade: `icon-shade-dark-default hover:bg-shade-white-hover focus-visible:bg-shade-white-hover outline-shade-light-default hover:outline-shade-medium-default focus-visible:outline-shade-medium-default`,
-          primary: `icon-primary-dark-default hover:bg-primary-light-hover focus-visible:bg-primary-light-hover outline-primary-light-default hover:outline-primary-medium-default focus-visible:outline-primary-medium-default`,
-          secondary: `icon-secondary-dark-default hover:bg-secondary-light-hover outline-secondary-light-default hover:outline-secondary-medium-default focus-visible:outline-secondary-medium-default`,
-          positive: `icon-positive-dark-default hover:bg-positive-light-hover focus-visible:bg-positive-light-hover outline-positive-light-default hover:outline-positive-medium-default focus-visible:outline-positive-medium-default`,
-          negative: `icon-negative-dark-default hover:bg-negative-light-hover focus-visible:bg-negative-light-hover outline-negative-light-default hover:outline-negative-medium-default focus-visible:outline-negative-medium-default`,
-          notice: `icon-notice-dark-default hover:bg-notice-light-hover focus-visible:bg-notice-light-hover outline-notice-light-default hover:outline-notice-medium-default focus-visible:outline-notice-medium-default`,
-          informative: `icon-informative-dark-default hover:bg-informative-light-hover focus-visible:bg-informative-light-hover outline-informative-light-default hover:outline-informative-medium-default focus-visible:outline-informative-medium-default`,
-        }[intention],
-      ])}
-      {...rest}
-    >
-      {icon}
-    </button>
-  </span>
+type LimitedChipProps<As extends ElementType = 'span'> = Omit<ChipProps<As>, 'clickableArea'>;
+
+type LimitedChipComponent = <As extends ElementType = 'span'>(props: LimitedChipProps<As>) => JSX.Element | null;
+
+export const LimitedChip: LimitedChipComponent = forwardRef(
+  <As extends ElementType = 'span'>(props: LimitedChipProps<As>, ref: Ref<As>): JSX.Element => {
+    const { as, label, icon = <MdClose />, intention = 'shade', onClick, className, ...rest } = props;
+    const Component: ElementType = as || 'button';
+
+    return (
+      <span
+        ref={ref}
+        className={fsx([
+          `shadow-attractive inline-flex h-fit w-fit flex-row items-center justify-center gap-1 break-keep rounded px-2 pr-0 outline outline-1 -outline-offset-1`,
+          {
+            shade: `bg-shade-white-default outline-shade-medium-default`,
+            primary: `bg-primary-light-default outline-primary-medium-default`,
+            secondary: `bg-secondary-light-default outline-secondary-medium-default`,
+            positive: `bg-positive-light-default outline-positive-medium-default`,
+            negative: `bg-negative-light-default outline-negative-medium-default`,
+            notice: `bg-notice-light-default outline-notice-medium-default`,
+            informative: `bg-informative-light-default outline-informative-medium-default`,
+          }[intention],
+          className,
+        ])}
+      >
+        <Text
+          className={fsx([
+            `flex items-center`,
+            {
+              shade: `text-shade-dark-default`,
+              primary: `text-primary-dark-default`,
+              secondary: `text-secondary-dark-default`,
+              positive: `text-positive-dark-default`,
+              negative: `text-negative-dark-default`,
+              notice: `text-notice-dark-default`,
+              informative: `text-informative-dark-default`,
+            }[intention],
+          ])}
+        >
+          {label}
+        </Text>
+        <Component
+          onClick={onClick}
+          className={fsx([
+            `focus-visible:shadow-focused flex h-6 w-6 flex-row items-start rounded-r p-1 outline outline-1 -outline-offset-1 [&_svg]:h-full [&_svg]:w-full`,
+            {
+              shade: `icon-shade-dark-default hover:bg-shade-white-hover focus-visible:bg-shade-white-hover outline-shade-light-default hover:outline-shade-medium-default focus-visible:outline-shade-medium-default`,
+              primary: `icon-primary-dark-default hover:bg-primary-light-hover focus-visible:bg-primary-light-hover outline-primary-light-default hover:outline-primary-medium-default focus-visible:outline-primary-medium-default`,
+              secondary: `icon-secondary-dark-default hover:bg-secondary-light-hover outline-secondary-light-default hover:outline-secondary-medium-default focus-visible:outline-secondary-medium-default`,
+              positive: `icon-positive-dark-default hover:bg-positive-light-hover focus-visible:bg-positive-light-hover outline-positive-light-default hover:outline-positive-medium-default focus-visible:outline-positive-medium-default`,
+              negative: `icon-negative-dark-default hover:bg-negative-light-hover focus-visible:bg-negative-light-hover outline-negative-light-default hover:outline-negative-medium-default focus-visible:outline-negative-medium-default`,
+              notice: `icon-notice-dark-default hover:bg-notice-light-hover focus-visible:bg-notice-light-hover outline-notice-light-default hover:outline-notice-medium-default focus-visible:outline-notice-medium-default`,
+              informative: `icon-informative-dark-default hover:bg-informative-light-hover focus-visible:bg-informative-light-hover outline-informative-light-default hover:outline-informative-medium-default focus-visible:outline-informative-medium-default`,
+            }[intention],
+          ])}
+          {...rest}
+        >
+          {icon}
+        </Component>
+      </span>
+    );
+  },
 );

--- a/packages/for-ui/src/system/polyComponent.ts
+++ b/packages/for-ui/src/system/polyComponent.ts
@@ -1,0 +1,22 @@
+import { ComponentPropsWithoutRef, ComponentPropsWithRef, ElementType } from 'react';
+import { PreservedOmit } from './preservedOmit';
+
+export type Ref<As extends ElementType> = ComponentPropsWithRef<As>['ref'];
+
+export type RefProps<As extends ElementType> = { ref?: Ref<As> };
+
+export type AsProps<As extends ElementType> = {
+  /**
+   * レンダリングするコンポーネントを指定 (例: button, a, input)
+   */
+  as?: As;
+};
+
+export type ComponentProps<Props extends object, As extends ElementType> = AsProps<As> &
+  Props &
+  RefProps<As> &
+  PreservedOmit<ComponentPropsWithoutRef<As>, keyof (Props & AsProps<As> & RefProps<As>)>;
+
+export type ElementTypeToHTMLElement<Element extends ElementType> = Element extends keyof HTMLElementTagNameMap
+  ? HTMLElementTagNameMap[Element]
+  : Element;

--- a/packages/for-ui/src/system/preservedOmit.ts
+++ b/packages/for-ui/src/system/preservedOmit.ts
@@ -1,0 +1,3 @@
+export type PreservedOmit<T, K extends keyof T> = {
+  [Property in keyof T as Exclude<Property, K>]: T[Property];
+};


### PR DESCRIPTION
## チケット

- Close #1226 

## 実装内容

- Chipに `as` propsを追加
- `forwardRef`するように修正
- `forwardRef` + `as` propsの標準的な書き方を規定
  - 便利型を `/system/polyComponent.ts` に置きました
  - 順次他のコンポーネントもこの書き方に移していきたいです

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
