### PR TITLE
fix(TextField): 入力欄のテキストサイズを修正

### DIFF
--- a/.changeset/dull-cooks-fail.md
+++ b/.changeset/dull-cooks-fail.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(TextField): 入力欄のテキストサイズを修正

--- a/packages/for-ui/src/textField/TextField.tsx
+++ b/packages/for-ui/src/textField/TextField.tsx
@@ -158,7 +158,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
             placeholder={placeholder}
             classes={{
               root: fsx([
-                `bg-shade-white-default flex w-full flex-wrap gap-1 p-0`,
+                `bg-shade-white-default text-r flex w-full flex-wrap gap-1 p-0`,
                 {
                   large: [`py-2 pl-2`, prefix && `py-0 pl-0`, suffix && `py-0 pr-0`],
                   medium: [`py-1 pl-1`, prefix && `py-0 pl-0`, suffix && `py-0 pr-0`],


### PR DESCRIPTION
## チケット

- Close #1236 

## 実装内容

- TextFieldの入力欄のテキストサイズがMUI由来で16pxになっていたのを修正

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
