### PR TITLE
fix(TextArea): アクセシビリティ的問題を修正

### DIFF
--- a/.changeset/proud-nails-heal.md
+++ b/.changeset/proud-nails-heal.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(TextArea): アクセシビリティ的問題を修正

--- a/packages/for-ui/src/textArea/TextArea.tsx
+++ b/packages/for-ui/src/textArea/TextArea.tsx
@@ -99,6 +99,9 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       helperText,
       label,
       required,
+      'aria-describedby': ariaDescribedby,
+      'aria-invalid': ariaInvalid,
+      'aria-errormessage': ariaErrormessage,
       id: passedId,
       ...props
     },
@@ -106,6 +109,8 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   ) => {
     const innerId = useId();
     const id = passedId || innerId;
+    const helperTextId = useId();
+
     return (
       <div className={fsx(`flex w-full flex-col gap-1`, className)}>
         <fieldset className={fsx(`contents`)}>
@@ -130,7 +135,11 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           )}
           <TextareaAutosize
             {...props}
+            aria-invalid={ariaInvalid || error}
+            aria-errormessage={error && helperText ? helperTextId : ariaErrormessage}
+            aria-describedby={!error && helperText ? helperTextId : ariaDescribedby}
             id={id}
+            required={required}
             disabled={disabled}
             minRows={rows || minRows}
             maxRows={rows || maxRows}
@@ -151,6 +160,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           content={helperText}
           defaultRenderer={(props) => (
             <Text
+              id={helperTextId}
               size="s"
               weight="regular"
               className={fsx(`text-shade-dark-default`, error && `text-negative-dark-default`)}


### PR DESCRIPTION
## チケット

- Close #1247 

## 実装内容

- requiredを内部のtextareaに渡るように修正
- helperTextを `aria-errormessage` と `aria-describedby` に対応させた

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
