### PR TITLE
fix(Select): 横幅を縮めたときに表示が崩れるのを修正

### DIFF
--- a/.changeset/perfect-sloths-remain.md
+++ b/.changeset/perfect-sloths-remain.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(Select): 横幅を縮めたときに表示が崩れるのを修正

--- a/packages/for-ui/src/select/Select.tsx
+++ b/packages/for-ui/src/select/Select.tsx
@@ -150,7 +150,7 @@ const _Select = <
     classes={{
       root: fsx(`w-full p-0`, className),
       paper: fsx(`min-w-min`),
-      inputRoot: fsx(`p-0`),
+      inputRoot: fsx(`p-0 [&_.MuiInputBase-root]:flex-wrap`),
       tag: fsx(`m-0 max-w-[none]`),
       listbox: fsx(`p-0`),
       input: fsx([multiple && `min-w-20`, disableFilter && `cursor-pointer caret-transparent`]),

--- a/packages/for-ui/src/select/Select.tsx
+++ b/packages/for-ui/src/select/Select.tsx
@@ -153,7 +153,7 @@ const _Select = <
       inputRoot: fsx(`p-0`),
       tag: fsx(`m-0 max-w-[none]`),
       listbox: fsx(`p-0`),
-      input: fsx([`min-w-20`, disableFilter && `cursor-pointer caret-transparent`]),
+      input: fsx([multiple && `min-w-20`, disableFilter && `cursor-pointer caret-transparent`]),
       noOptions: fsx(`p-0`),
       endAdornment: fsx([
         `[&_svg]:icon-shade-dark-default border-shade-light-default [input:disabled+&_svg]:icon-shade-dark-disabled static flex border-x`,

--- a/packages/for-ui/src/textField/TextField.tsx
+++ b/packages/for-ui/src/textField/TextField.tsx
@@ -158,7 +158,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
             placeholder={placeholder}
             classes={{
               root: fsx([
-                `bg-shade-white-default text-r flex w-full flex-wrap gap-1 p-0`,
+                `bg-shade-white-default text-r flex w-full flex-nowrap gap-1 p-0`,
                 {
                   large: [`py-2 pl-2`, prefix && `py-0 pl-0`, suffix && `py-0 pr-0`],
                   medium: [`py-1 pl-1`, prefix && `py-0 pl-0`, suffix && `py-0 pr-0`],
@@ -168,7 +168,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
                 `bg-shade-white-disabled placeholder:text-shade-light-default text-shade-light-disabled cursor-not-allowed [-webkit-text-fill-color:currentColor_!important]`,
               ),
               input: fsx([
-                `text-r text-shade-dark-default placeholder:text-shade-light-default h-auto w-auto grow p-0 font-sans placeholder:opacity-100 focus:shadow-none`,
+                `text-r text-shade-dark-default placeholder:text-shade-light-default h-auto grow p-0 font-sans placeholder:opacity-100 focus:shadow-none`,
                 {
                   large: [`px-2`, icon && `pl-1`],
                   medium: [`px-1`, icon && `pl-1`],


### PR DESCRIPTION
## チケット

- Close #1239 

## 実装内容

- multipleの場合のみinputの最小幅を入れた
  - multipleの場合は同様の問題が残るが入力できないよりは表示が崩れているほうが良いという判断

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
