### PR TITLE
fix(Stepper): デザイン改善

### DIFF
--- a/.changeset/long-parrots-check.md
+++ b/.changeset/long-parrots-check.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(Stepper): デザイン改善

--- a/packages/for-ui/src/stepper/Step.tsx
+++ b/packages/for-ui/src/stepper/Step.tsx
@@ -1,51 +1,47 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
+import { MdOutlineDone } from 'react-icons/md';
 import MuiStep, { StepProps as MuiStepProps } from '@mui/material/Step';
 import { StepIconProps as MuiStepIconProps } from '@mui/material/StepIcon';
 import MuiStepLabel, { StepLabelProps as MuiStepLabelProps } from '@mui/material/StepLabel';
 import { fsx } from '../system/fsx';
+import { Text } from '../text';
 
 export type StepProps = MuiStepProps;
 
 export type StepLabelProps = MuiStepLabelProps;
 
-export const Step = forwardRef<HTMLDivElement, StepProps & StepLabelProps>((props, ref) => {
-  const { children, ...rest } = props;
-  return (
-    <MuiStep ref={ref} {...rest}>
-      <MuiStepLabel
-        ref={ref}
-        StepIconComponent={Icon}
-        classes={{
-          root: fsx(['mt-0']),
-          label: fsx(['text-r text-shade-dark-default mt-2 font-normal']),
-          completed: fsx(['text-r text-shade-dark-default font-normal']),
-          active: fsx(['text-r text-shade-dark-default font-normal']),
-          iconContainer: fsx(['mt-2']),
-        }}
-      >
+export const Step = forwardRef<HTMLDivElement, StepProps>(({ children, active, className, ...rest }, ref) => (
+  <MuiStep ref={ref} active={active} className={fsx(`p-0`, className)} {...rest}>
+    <MuiStepLabel
+      className={fsx(`m-0 flex gap-1`)}
+      StepIconComponent={Icon}
+      classes={{
+        label: fsx(`m-0 font-sans`),
+        iconContainer: fsx(`p-0`),
+        active: fsx(`font-bold`),
+      }}
+    >
+      <Text size="r" className="text-shade-dark-default">
         {children}
-      </MuiStepLabel>
-    </MuiStep>
-  );
-});
+      </Text>
+    </MuiStepLabel>
+  </MuiStep>
+));
 
-const Icon = (props: Partial<MuiStepIconProps>) => {
-  const { completed, active, icon } = props;
-
-  return (
-    <>
-      <span
-        className={fsx([
-          'text-r relative h-8 w-8 rounded-full  border-2 font-bold',
-          active
-            ? 'border-primary-dark-default bg-shade-white-default text-primary-dark-default border-2'
-            : completed
-            ? 'bg-primary-dark-default text-shade-white-default border-0'
-            : 'border-primary-dark-disabled bg-shade-white-disabled text-shade-dark-disabled',
-        ])}
-      >
-        <span className={fsx(['absolute left-2/4 top-2/4 -translate-x-2/4 -translate-y-2/4'])}>{icon}</span>
-      </span>
-    </>
-  );
-};
+const Icon = ({ completed, active, icon }: Partial<MuiStepIconProps>) => (
+  <span
+    className={fsx([
+      `grid h-6 w-6 place-content-center rounded-full`,
+      completed && `bg-primary-dark-default [&_svg]:fill-shade-white-default [&_svg]:h-4 [&_svg]:w-4`,
+      active && `border-primary-dark-default border-2`,
+      !active && !completed && `border-shade-dark-disabled border-2`,
+    ])}
+  >
+    <Text
+      weight={active ? 'bold' : 'regular'}
+      className={fsx([active && `text-primary-dark-default`, !active && !completed && `text-shade-dark-default`])}
+    >
+      {completed ? <MdOutlineDone /> : icon}
+    </Text>
+  </span>
+);

--- a/packages/for-ui/src/stepper/Stepper.stories.tsx
+++ b/packages/for-ui/src/stepper/Stepper.stories.tsx
@@ -12,51 +12,63 @@ export default {
     alternativeLabel: { control: 'boolean' },
     backgroundColor: { control: 'color' },
   },
-  decorators: [
-    (Story: Story) => (
-      <div className="mt-10">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [(Story: Story) => <Story />],
 } as Meta;
 
 const steps = ['First', 'Second', 'Third', 'Last'];
 
-const Template: Story = (args) => {
-  return (
-    <div>
-      <div className="mb-4 border-b">
-        <Text as="h3" size="l" weight="bold">
-          Stepper
-        </Text>
-      </div>
-      <Stepper alternativeLabel={true} activeStep={0} {...args}>
-        {steps.map((step, index) => (
-          <Step key={index}>{step}</Step>
-        ))}
-      </Stepper>
-      <Stepper alternativeLabel={true} activeStep={1} {...args}>
-        {steps.map((step, index) => (
-          <Step key={index}>{step}</Step>
-        ))}
-      </Stepper>
-      <Stepper alternativeLabel={true} activeStep={2} {...args}>
-        {steps.map((step, index) => (
-          <Step key={index}>{step}</Step>
-        ))}
-      </Stepper>
-      <Stepper alternativeLabel={true} activeStep={3} {...args}>
-        {steps.map((step, index) => (
-          <Step key={index}>{step}</Step>
-        ))}
-      </Stepper>
-    </div>
-  );
-};
+export const LabelBottom: Story = (args) => (
+  <div className="flex flex-col gap-6">
+    <Text as="h3" size="l" weight="bold">
+      Stepper
+    </Text>
+    <Stepper labelPosition="bottom" activeStep={0} {...args}>
+      {steps.map((step, index) => (
+        <Step key={index}>{step}</Step>
+      ))}
+    </Stepper>
+    <Stepper labelPosition="bottom" activeStep={1} {...args}>
+      {steps.map((step, index) => (
+        <Step key={index}>{step}</Step>
+      ))}
+    </Stepper>
+    <Stepper labelPosition="bottom" activeStep={2} {...args}>
+      {steps.map((step, index) => (
+        <Step key={index}>{step}</Step>
+      ))}
+    </Stepper>
+    <Stepper labelPosition="bottom" activeStep={3} {...args}>
+      {steps.map((step, index) => (
+        <Step key={index}>{step}</Step>
+      ))}
+    </Stepper>
+  </div>
+);
 
-export const Basic = Template.bind({});
-
-Basic.args = {
-  alternativeLabel: true,
-};
+export const LabelTrailing: Story = (args) => (
+  <div className="flex flex-col gap-6">
+    <Text as="h3" size="l" weight="bold">
+      Stepper
+    </Text>
+    <Stepper labelPosition="trailing" activeStep={0} {...args}>
+      {steps.map((step, index) => (
+        <Step key={index}>{step}</Step>
+      ))}
+    </Stepper>
+    <Stepper labelPosition="trailing" activeStep={1} {...args}>
+      {steps.map((step, index) => (
+        <Step key={index}>{step}</Step>
+      ))}
+    </Stepper>
+    <Stepper labelPosition="trailing" activeStep={2} {...args}>
+      {steps.map((step, index) => (
+        <Step key={index}>{step}</Step>
+      ))}
+    </Stepper>
+    <Stepper labelPosition="trailing" activeStep={3} {...args}>
+      {steps.map((step, index) => (
+        <Step key={index}>{step}</Step>
+      ))}
+    </Stepper>
+  </div>
+);

--- a/packages/for-ui/src/stepper/Stepper.tsx
+++ b/packages/for-ui/src/stepper/Stepper.tsx
@@ -1,50 +1,44 @@
 import { forwardRef } from 'react';
-import { StepConnector, stepConnectorClasses } from '@mui/material';
+import { StepConnector } from '@mui/material';
 import MuiStepper, { StepperProps as MuiStepperProps } from '@mui/material/Stepper';
 import { fsx } from '../system/fsx';
 
-export type StepperProps = MuiStepperProps & {
+export type StepperProps = Omit<MuiStepperProps, 'alternativeLabel'> & {
+  /**
+   * ラベルを表示する位置を指定
+   *
+   * @default 'bottom'
+   */
+  labelPosition?: 'bottom' | 'trailing';
+
+  /**
+   * @deprecated labelPositionを使用してください
+   */
+  alternativeLabel?: MuiStepperProps['alternativeLabel'];
+
   className?: string;
 };
 
 export const Stepper = forwardRef<HTMLDivElement, StepperProps>(
-  ({ activeStep, alternativeLabel, children, className, ...rest }, ref) => {
-    return (
-      <MuiStepper
-        ref={ref}
-        activeStep={activeStep}
-        alternativeLabel={alternativeLabel}
-        connector={
-          <StepConnector
-            classes={{
-              root: fsx('left-[calc(-50%+1rem)] right-[calc(50%+1rem)] top-6 px-0', className),
-              line: fsx('border-t-2'),
-            }}
-            sx={{
-              [`&.${stepConnectorClasses.active}`]: {
-                [`& .${stepConnectorClasses.line}`]: {
-                  borderColor: 'var(--shade-border-dark-default)',
-                },
-              },
-
-              [`&.${stepConnectorClasses.completed}`]: {
-                [`& .${stepConnectorClasses.line}`]: {
-                  borderColor: 'var(--shade-border-dark-default)',
-                },
-              },
-
-              [`&.${stepConnectorClasses.disabled}`]: {
-                [`& .${stepConnectorClasses.line}`]: {
-                  borderColor: 'var(--shade-border-dark-disabled)',
-                },
-              },
-            }}
-          />
-        }
-        {...rest}
-      >
-        {children}
-      </MuiStepper>
-    );
-  },
+  ({ activeStep, alternativeLabel, labelPosition = 'bottom', children, className, ...rest }, ref) => (
+    <MuiStepper
+      ref={ref}
+      activeStep={activeStep}
+      alternativeLabel={alternativeLabel || { bottom: true, trailing: false }[labelPosition]}
+      connector={
+        <StepConnector
+          classes={{
+            root: fsx(
+              `[&:is(.Mui-active,.Mui-completed)>.MuiStepConnector-line]:border-primary-dark-default -left-2/4 right-0 top-0 flex h-6 w-full items-center px-0 [&.MuiStepConnector-alternativeLabel]:pl-3 [&.MuiStepConnector-alternativeLabel]:pr-4`,
+            ),
+            line: fsx(`border-shade-dark-disabled w-full border-t-2`),
+          }}
+        />
+      }
+      className={fsx(`gap-1`, className)}
+      {...rest}
+    >
+      {children}
+    </MuiStepper>
+  ),
 );


### PR DESCRIPTION
## チケット

- Close #1282 
  - Close #1265 
  - Close #1266 
  - Close #1270 
  - Close #1271 

## 実装内容

- v1.1.0のデザイン改善時に漏れていたStepperのデザイン改善を入れた
  - 「入力の終わったもの」と「現在取り組んでいるもの」の見分けがつきにくい問題を解決
  - ラベルを後方におくタイプの作成
  - Stepperの大きさや色を見直して、デザイン改善後の他のコンポーネントと並べたときに主張が強すぎないように修正
  - `alternativeLabel` propを廃止し、`labelPosition` propで置き換え

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|   <img width="1416" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/b3236591-101a-40e6-ae74-61cd48dbb8d2">     |   <img width="1418" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/6a115950-cfe8-4945-8a84-c2596a49cdaa"> 
| 該当なし | <img width="1417" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/5f868922-bdb2-4b7f-b666-69096eba983d">   |

## 相談内容(あれば)

-
