### PR TITLE
fix(Table): 選択可能なTableのバグ修正とヘッダの高さ等を整える修正

### DIFF
--- a/.changeset/dull-kangaroos-scream.md
+++ b/.changeset/dull-kangaroos-scream.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(Table): 選択可能なTableのバグ修正とヘッダの高さ等を整える修正

--- a/packages/for-ui/src/chip/Chip.tsx
+++ b/packages/for-ui/src/chip/Chip.tsx
@@ -55,27 +55,3 @@ export const Chip: ChipComponent = forwardRef(
       limited: <LimitedChip<As> {...props} ref={ref} />,
     }[clickableArea]),
 );
-
-////////////////////
-
-// const _Chip = <As extends ElementType = 'button'>({
-//   clickableArea = 'full',
-//   ...props
-// }: ChipPropsWithoutRef<As> & { _ref?: ComponentPropsWithRef<As>["ref"]; }): JSX.Element =>
-//   ({
-//     full: <FullChip<As> {...props} />,
-//     limited: <LimitedChip<As> {...props} />,
-//   }[clickableArea]);
-
-// export type ChipProps<As extends ElementType = 'button'> = ChipPropsWithoutRef<As> &
-// // {  ref?: Ref<As extends keyof HTMLElementTagNameMap ? HTMLElementTagNameMap[As] : As> };
-// RefAttributes<ComponentPropsWithRef<As>["ref"]>
-
-// export const Chip = forwardRef((props: ChipPropsWithoutRef<ElementType>, ref: ComponentPropsWithRef<ElementType>["ref"]) => (
-//   <_Chip {...props} _ref={ref} />
-// )) as <As extends ElementType = 'button'>(props: ChipProps<As>) => JSX.Element | null;
-
-// type ChipProps<As extends ElementType = 'button'> = PolymorphicComponentPropWithRef<
-//   As,
-//   ChipPropsWithoutRef
-// >

--- a/packages/for-ui/src/table/Table.stories.tsx
+++ b/packages/for-ui/src/table/Table.stories.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
+import { MdMoreVert, MdOutlineDelete, MdOutlineEdit } from 'react-icons/md';
 import { Meta, Story } from '@storybook/react/types-6-0';
+import { Badge } from '../badge';
+import { Button } from '../button';
+import { Menu, MenuItem } from '../menu';
+import { Select } from '../select';
+import { Text } from '../text';
 import { PersonData, StaticPersonData } from '../utils/makeData';
 import { ColumnDef } from './ColumnDef';
-import { Table } from './Table';
+import { Table, TableBody, TableFrame, TableHead, TableRow } from './Table';
 import { TableCell } from './TableCell';
 import { TableScroller } from './TableScroller';
 
@@ -89,4 +95,110 @@ export const WithClickRow: Story = () => (
       console.info(row);
     }}
   />
+);
+
+export const WithoutReactTable: Story = () => (
+  <TableFrame className="">
+    <TableHead>
+      <TableRow>
+        <TableCell as="th">出版社</TableCell>
+        <TableCell as="th">本</TableCell>
+        <TableCell as="th">状態</TableCell>
+        <TableCell as="th" aria-label="アクション"></TableCell>
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      <TableRow>
+        <TableCell>東京大学出版会</TableCell>
+        <TableCell>記号と再帰</TableCell>
+        <TableCell className="w-64">
+          <Select
+            name="state"
+            size="medium"
+            options={[
+              { label: '在庫あり', inputValue: 'available' },
+              { label: '貸出中', inputValue: 'unavailable' },
+            ]}
+            defaultValue={{ label: '貸出中', inputValue: 'unavailable' }}
+          />
+        </TableCell>
+        <TableCell className="w-4">
+          <Menu
+            TriggerComponent={
+              <Button intention="shade" size="small" variant="text">
+                <MdMoreVert />
+              </Button>
+            }
+          >
+            <MenuItem icon={<MdOutlineEdit />}>編集</MenuItem>
+            <MenuItem icon={<MdOutlineDelete />} intention="negative">
+              削除
+            </MenuItem>
+          </Menu>
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell rowSpan={2}>技術評論社</TableCell>
+        <TableCell>
+          <Text className="flex gap-1">
+            オブジェクト指向UIデザイン
+            <Badge intention="primary" variant="outlined" label="必読" />
+          </Text>
+        </TableCell>
+        <TableCell className="w-64">
+          <Select
+            name="state"
+            size="medium"
+            options={[
+              { label: '在庫あり', inputValue: 'available' },
+              { label: '貸出中', inputValue: 'unavailable' },
+            ]}
+            defaultValue={{ label: '貸出中', inputValue: 'unavailable' }}
+          />
+        </TableCell>
+        <TableCell className="w-4">
+          <Menu
+            TriggerComponent={
+              <Button intention="shade" size="small" variant="text">
+                <MdMoreVert />
+              </Button>
+            }
+          >
+            <MenuItem icon={<MdOutlineEdit />}>編集</MenuItem>
+            <MenuItem icon={<MdOutlineDelete />} intention="negative">
+              削除
+            </MenuItem>
+          </Menu>
+        </TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell>Webアプリケーションアクセシビリティ</TableCell>
+        <TableCell className="w-64">
+          <Select
+            name="state"
+            size="medium"
+            options={[
+              { label: '在庫あり', inputValue: 'available' },
+              { label: '貸出中', inputValue: 'unavailable' },
+            ]}
+            defaultValue={{ label: '在庫あり', inputValue: 'available' }}
+          />
+        </TableCell>
+        <TableCell className="w-4">
+          <Menu
+            TriggerComponent={
+              <Button intention="shade" size="small" variant="text">
+                <MdMoreVert />
+              </Button>
+            }
+          >
+            <MenuItem icon={<MdOutlineEdit />}>編集</MenuItem>
+            <MenuItem icon={<MdOutlineDelete />} intention="negative">
+              削除
+            </MenuItem>
+          </Menu>
+        </TableCell>
+      </TableRow>
+    </TableBody>
+  </TableFrame>
 );

--- a/packages/for-ui/src/table/Table.tsx
+++ b/packages/for-ui/src/table/Table.tsx
@@ -18,6 +18,7 @@ import {
 import { Checkbox } from '../checkbox';
 import { Radio } from '../radio';
 import { fsx } from '../system/fsx';
+import { Text } from '../text';
 import { SortableTableCellHead, TableCell } from './TableCell';
 import { TablePagination } from './TablePagination';
 
@@ -112,6 +113,11 @@ export const Table = <T extends RowData>({
         <Fragment>
           {!!onSelectRows && (
             <Checkbox
+              label={
+                <Text aria-hidden={false} className={fsx(`hidden`)}>
+                  すべての行を選択
+                </Text>
+              }
               className={fsx(`flex`)}
               checked={table.getIsAllRowsSelected()}
               indeterminate={!table.getIsAllRowsSelected() && table.getIsSomeRowsSelected()}
@@ -121,9 +127,14 @@ export const Table = <T extends RowData>({
         </Fragment>
       ),
       cell: ({ row }) => (
-        <TableCell>
+        <TableCell as="th" scope="row">
           {!!onSelectRows && (
             <Checkbox
+              label={
+                <Text aria-hidden={false} className={fsx(`hidden`)}>
+                  行を選択
+                </Text>
+              }
               className={fsx(`flex`)}
               checked={row.getIsSelected()}
               onClick={(e) => {
@@ -134,6 +145,11 @@ export const Table = <T extends RowData>({
           )}
           {!!onSelectRow && (
             <Radio
+              label={
+                <Text aria-hidden={false} className={fsx(`hidden`)}>
+                  行を選択
+                </Text>
+              }
               className={fsx(`flex`)}
               checked={row.getIsSelected()}
               onClick={(e) => {

--- a/packages/for-ui/src/table/TableCell.tsx
+++ b/packages/for-ui/src/table/TableCell.tsx
@@ -1,36 +1,87 @@
-import React from 'react';
-import { PropsWithChildren } from 'react';
+import { FC, forwardRef, HTMLAttributes, ReactNode } from 'react';
+import { MdArrowDownward, MdArrowUpward } from 'react-icons/md';
 import { fsx } from '../system/fsx';
+import { ComponentProps, Ref } from '../system/polyComponent';
+import { Text } from '../text';
 
-export type TableCellProps = PropsWithChildren<{
-  component?: 'th' | 'td';
-  className?: string;
-}>;
+export type TableCellProps<As extends 'th' | 'td' = 'td'> = ComponentProps<
+  {
+    /**
+     * @deprecated `as` propを使ってください
+     */
+    component?: 'th' | 'td';
 
-export const TableCell = ({ component = 'td', className, children, ...rest }: TableCellProps) => {
-  return (
-    <>
-      {component === 'td' ? (
-        <td
-          className={fsx([
-            'border-shade-light-default text-shade-dark-default text-r border-b px-3 py-2 text-left font-normal',
-            className,
-          ])}
-          {...rest}
+    className?: string;
+  },
+  As
+>;
+
+type TableCellComponent = <As extends 'th' | 'td' = 'td'>(props: TableCellProps<As>) => JSX.Element | null;
+
+export const TableCell: TableCellComponent = forwardRef(
+  <As extends 'th' | 'td' = 'td'>({ component = 'td', as, className, ...rest }: TableCellProps<As>, ref?: Ref<As>) => {
+    const Component = as || component || 'td';
+    return (
+      <Component
+        className={fsx([
+          `border-shade-light-default text-shade-dark-default border-t px-3 text-left`,
+          {
+            th: `py-1 font-bold break-keep`,
+            td: `py-2 font-normal`,
+          }[Component],
+          className,
+        ])}
+        ref={ref}
+        {...rest}
+      />
+    );
+  },
+);
+
+export const SortableTableCellHead: FC<
+  TableCellProps<'th'> & {
+    sortable: boolean;
+    sorted: false | 'asc' | 'desc';
+    nextSortingOrder: false | 'asc' | 'desc';
+    children: ReactNode;
+    onClick?: HTMLAttributes<HTMLButtonElement>['onClick'];
+  }
+> = ({ sortable, sorted, nextSortingOrder, onClick, children, ...rest }) => (
+  <TableCell
+    as="th"
+    aria-sort={sorted ? ({ asc: 'ascending', desc: 'descending' } as const)[sorted] : undefined}
+    className={fsx(sortable && `p-0`)}
+    {...rest}
+  >
+    {sortable ? (
+      <button
+        onClick={onClick}
+        className={fsx(
+          `hover:bg-shade-light-hover focus-visible:bg-shade-light-hover group flex w-full items-center gap-1 px-3 py-1 focus-visible:outline-none`,
+        )}
+      >
+        {children}
+        <span
+          aria-hidden
+          className={fsx(
+            `fill-shade-dark-default [&_svg]:h-4 [&_svg]:w-4 [&_svg]:fill-inherit`,
+            !sorted && `fill-shade-medium-default`,
+          )}
         >
-          {children}
-        </td>
-      ) : (
-        <th
-          className={fsx([
-            'border-shade-light-default text-shade-dark-default text-r border-b px-3 py-2 text-left font-normal',
-            className,
-          ])}
-          {...rest}
-        >
-          {children}
-        </th>
-      )}
-    </>
-  );
-};
+          {sorted
+            ? {
+                asc: <MdArrowUpward />,
+                desc: <MdArrowDownward />,
+              }[sorted]
+            : nextSortingOrder &&
+              {
+                asc: <MdArrowUpward className={fsx(`invisible group-hover:visible`)} />,
+                desc: <MdArrowDownward className={fsx(`invisible group-hover:visible`)} />,
+              }[nextSortingOrder]}
+        </span>
+      </button>
+    ) : (
+      <Text className={fsx(`flex items-center`)}>{children}</Text>
+    )}
+  </TableCell>
+);

--- a/packages/for-ui/src/table/TableScroller.tsx
+++ b/packages/for-ui/src/table/TableScroller.tsx
@@ -1,20 +1,14 @@
 import { PropsWithChildren } from 'react';
-import { fsx } from '../system/fsx';
 
 type Props = PropsWithChildren<{
   height?: number | string;
 }>;
 
-export const TableScroller = ({ height, children }: Props) => (
+export const TableScroller = ({ height, ...rest }: Props) => (
   <div
     style={{
-      height: typeof height === 'string' ? height : typeof height === 'number' ? `${height}px` : 'auto',
+      height: height ? height : 'auto',
     }}
-    className={fsx([
-      `overflow-y-auto`,
-      '[&_table>thead_th]:z-table [&_table>thead_th]:sticky [&_table>thead_th]:top-0',
-    ])}
-  >
-    {children}
-  </div>
+    {...rest}
+  />
 );


### PR DESCRIPTION
## チケット

- Close #1292 
  - Close #1291 
  - Close #1272 
  - Close #881 

## 実装内容

- 選択可能なTableで不要な文言が出ていたのを修正
- `react-table` を使わないtableのためのスタイルつきコンポーネントを作成 & export
- 並び順を変更できるテーブルのアクセシビリティ向上
- テーブルの高さを固定値にしたときにヘッダを固定表示するように修正
- 最後の行の下線を消す修正
- 並び替えできるヘッダについて、hoverで矢印を表示するように修正

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|   <img width="1417" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/8de9c64f-4aae-4157-aa7f-7cb44d11dcc7">     |     <img width="1418" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/098b125c-b6cf-4579-8689-d69df83dc3c9">   |

動作確認

https://github.com/4-design/for-ui/assets/8467289/583c82be-f60a-4b51-8699-618a0f7aebf0

| 状態 | スクリーンショット | 修正の意図 |
| -- | -- | -- |
| 高さ固定 (コンテンツよりも低い) | <img width="1176" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/45e33339-4ba1-4f84-a772-b321eebeee80"> | スクロールができてヘッダが固定されている、1番最後の行の下線が二重にならない |
| 高さ可変 (コンテンツによる) | <img width="1182" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/84ff32aa-4a88-4bf9-8735-6d56751b6ece"> | 1番最後の行の下線が二重にならない |
| 高さ固定 (コンテンツより高い) | <img width="1174" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/6e7bc136-cff5-4156-80cc-cf4ab9ce3b85"> | 1番最後の行に下線が表示されている |

## 相談内容(あれば)

-
