### PR TITLE
fix(deps): TypeScript v5.1.3にアップデート

### DIFF
--- a/.changeset/mean-bulldogs-smoke.md
+++ b/.changeset/mean-bulldogs-smoke.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(deps): TypeScript v5.1.3にアップデート

--- a/example/nextjs-app/package-lock.json
+++ b/example/nextjs-app/package-lock.json
@@ -28,7 +28,7 @@
         "next": "13.3.1",
         "postcss": "8.4.24",
         "tailwindcss": "3.3.2",
-        "typescript": "5.0.4",
+        "typescript": "5.1.3",
         "yalc": "1.0.0-pre.53"
       }
     },
@@ -2742,16 +2742,16 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/universalify": {
@@ -4808,9 +4808,9 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "devOptional": true
     },
     "universalify": {

--- a/example/nextjs-app/package.json
+++ b/example/nextjs-app/package.json
@@ -29,7 +29,7 @@
     "next": "13.3.1",
     "postcss": "8.4.24",
     "tailwindcss": "3.3.2",
-    "typescript": "5.0.4",
+    "typescript": "5.1.3",
     "yalc": "1.0.0-pre.53"
   },
   "volta": {

--- a/example/vite-app/package-lock.json
+++ b/example/vite-app/package-lock.json
@@ -29,7 +29,7 @@
         "postcss": "8.4.24",
         "prettier": "2.8.8",
         "tailwindcss": "3.3.2",
-        "typescript": "5.0.4",
+        "typescript": "5.1.3",
         "vite": "3.2.7",
         "yalc": "1.0.0-pre.53"
       }
@@ -4496,16 +4496,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/universalify": {

--- a/example/vite-app/package.json
+++ b/example/vite-app/package.json
@@ -29,7 +29,7 @@
     "postcss": "8.4.24",
     "prettier": "2.8.8",
     "tailwindcss": "3.3.2",
-    "typescript": "5.0.4",
+    "typescript": "5.1.3",
     "vite": "3.2.7",
     "yalc": "1.0.0-pre.53"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27451,7 +27451,7 @@
         "react-hook-form": "7.44.3",
         "react-icons": "4.9.0",
         "tailwindcss": "3.3.2",
-        "typescript": "5.0.4",
+        "typescript": "5.1.3",
         "vite": "3.2.5",
         "vitest": "0.31.4",
         "webpack": "5.76.0",
@@ -29658,6 +29658,19 @@
         "node": ">=10"
       }
     },
+    "packages/for-ui/node_modules/typescript": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "packages/for-ui/node_modules/vite": {
       "version": "4.0.4",
       "dev": true,
@@ -29851,7 +29864,7 @@
         "react-transition-group": "4.4.5",
         "tailwind-merge": "1.13.1",
         "tailwindcss": "3.3.2",
-        "typescript": "5.0.4",
+        "typescript": "5.1.3",
         "vite": "3.2.5",
         "vitest": "0.31.4",
         "webpack": "5.76.0",
@@ -31347,6 +31360,12 @@
             "commander": "^2.20.0",
             "source-map-support": "~0.5.20"
           }
+        },
+        "typescript": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "dev": true
         },
         "vite": {
           "version": "4.0.4",

--- a/packages/for-ui/package.json
+++ b/packages/for-ui/package.json
@@ -94,7 +94,7 @@
     "react-hook-form": "7.44.3",
     "react-icons": "4.9.0",
     "tailwindcss": "3.3.2",
-    "typescript": "5.0.4",
+    "typescript": "5.1.3",
     "vite": "3.2.5",
     "vitest": "0.31.4",
     "webpack": "5.76.0",

--- a/packages/for-ui/src/chip/Chip.tsx
+++ b/packages/for-ui/src/chip/Chip.tsx
@@ -46,7 +46,7 @@ export type ChipProps<As extends ElementType = 'button'> = ComponentProps<
   As
 >;
 
-type ChipComponent = <As extends ElementType = 'button'>(props: ChipProps<As>) => JSX.Element | null;
+type ChipComponent = <As extends ElementType = 'button'>(props: ChipProps<As>) => ReactNode;
 
 export const Chip: ChipComponent = forwardRef(
   <As extends ElementType = 'button'>({ clickableArea = 'full', ...props }: ChipProps<As>, ref?: Ref<As>) =>

--- a/packages/for-ui/src/chip/FullChip.tsx
+++ b/packages/for-ui/src/chip/FullChip.tsx
@@ -1,4 +1,4 @@
-import { ElementType, forwardRef } from 'react';
+import { ElementType, forwardRef, ReactNode } from 'react';
 import { fsx } from '../system/fsx';
 import { Ref } from '../system/polyComponent';
 import { Text } from '../text';
@@ -6,7 +6,7 @@ import { ChipProps } from './Chip';
 
 type FullChipProps<As extends ElementType = 'button'> = Omit<ChipProps<As>, 'clickableArea'>;
 
-type FullChipComponent = <As extends ElementType = 'button'>(props: FullChipProps<As>) => JSX.Element | null;
+type FullChipComponent = <As extends ElementType = 'button'>(props: FullChipProps<As>) => ReactNode;
 
 export const FullChip: FullChipComponent = forwardRef(
   <As extends ElementType = 'button'>(props: FullChipProps<As>, ref: Ref<As>): JSX.Element => {

--- a/packages/for-ui/src/chip/LimitedChip.tsx
+++ b/packages/for-ui/src/chip/LimitedChip.tsx
@@ -1,4 +1,4 @@
-import { ElementType, forwardRef } from 'react';
+import { ElementType, forwardRef, ReactNode } from 'react';
 import { MdClose } from 'react-icons/md';
 import { fsx } from '../system/fsx';
 import { Ref } from '../system/polyComponent';
@@ -7,7 +7,7 @@ import { ChipProps } from './Chip';
 
 type LimitedChipProps<As extends ElementType = 'span'> = Omit<ChipProps<As>, 'clickableArea'>;
 
-type LimitedChipComponent = <As extends ElementType = 'span'>(props: LimitedChipProps<As>) => JSX.Element | null;
+type LimitedChipComponent = <As extends ElementType = 'span'>(props: LimitedChipProps<As>) => ReactNode;
 
 export const LimitedChip: LimitedChipComponent = forwardRef(
   <As extends ElementType = 'span'>(props: LimitedChipProps<As>, ref: Ref<As>): JSX.Element => {

--- a/packages/for-ui/tsconfig.json
+++ b/packages/for-ui/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "typeRoots": [],
     "sourceMap": true,
     "allowJs": false,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## チケット

- Close #1303 

## 実装内容

- TypeScriptをv5.1.3にアップデート
- 明示的な`typeRoots`があると上位のnode_modulesを見に行かないため削除
- `React.FC`の型定義が変更されたことにより`JSX.Element | null`では不十分になったので修正

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
