### PR TITLE
fix(Table): スクロールバーを常に表示に設定しているときの意図しないpaddingを除去

### DIFF
--- a/.changeset/eleven-items-double.md
+++ b/.changeset/eleven-items-double.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(Table): スクロールバーを常に表示に設定しているときの意図しないpaddingを除去

--- a/packages/for-ui/src/table/Table.tsx
+++ b/packages/for-ui/src/table/Table.tsx
@@ -241,7 +241,7 @@ export const Table = <T extends RowData>({
 
 export const TableFrame = forwardRef<HTMLTableElement, JSX.IntrinsicElements['table']>(
   ({ className, ...props }, ref) => (
-    <div className={fsx(`border-shade-light-default h-full w-full overflow-scroll rounded border`, className)}>
+    <div className={fsx(`border-shade-light-default h-full w-full overflow-auto rounded border`, className)}>
       <table
         className={fsx(`ring-shade-light-default w-full border-separate border-spacing-0 ring-1`)}
         ref={ref}


### PR DESCRIPTION
## チケット

- Close #1361 

## 実装内容

- Tableのスクロールバーの領域がスクロールが発生しないときも常にpaddingが設定されているのを修正

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|   <img width="1195" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/5301611a-8adb-4108-b4bf-965a235ca969">     |    <img width="1196" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/9ffbab10-8f18-4823-aeb3-c12216b77b39">    |

## 相談内容(あれば)

-
