### PR TITLE
fix(Callout): レイアウトの修正

### DIFF
--- a/.changeset/six-pillows-work.md
+++ b/.changeset/six-pillows-work.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(Callout): レイアウトの修正

--- a/packages/for-ui/src/callout/Callout.tsx
+++ b/packages/for-ui/src/callout/Callout.tsx
@@ -25,9 +25,11 @@ export type CalloutProps = {
    * リンク等を入れられるようReactNodeにしてありますが、通常はstringを指定してください。Button等は含めないでください。
    */
   children: ReactNode;
+
+  className?: string;
 };
 
-export const Callout: FC<CalloutProps> = ({ icon, children, intention = 'subtle', ...props }) => {
+export const Callout: FC<CalloutProps> = ({ icon, children, intention = 'subtle', className, ...props }) => {
   const descriptionId = useId();
   return (
     <Text
@@ -35,7 +37,7 @@ export const Callout: FC<CalloutProps> = ({ icon, children, intention = 'subtle'
       aria-describedby={descriptionId}
       {...props}
       className={fsx([
-        `flex gap-1 rounded px-2 py-1 outline outline-1`,
+        `flex h-fit w-full items-start justify-start gap-1 rounded px-2 py-1 outline outline-1`,
         {
           subtle: `outline-shade-light-default text-shade-medium-default bg-shade-light-default fill-shade-medium-default`,
           positive: `outline-positive-light-default text-positive-dark-default bg-positive-light-default fill-positive-medium-default`,
@@ -43,6 +45,7 @@ export const Callout: FC<CalloutProps> = ({ icon, children, intention = 'subtle'
           notice: `outline-notice-light-default text-notice-dark-default bg-notice-light-default fill-notice-medium-default`,
           informative: `outline-informative-light-default text-informative-dark-default bg-informative-light-default fill-informative-medium-default`,
         }[intention],
+        className,
       ])}
     >
       {icon && (
@@ -53,7 +56,7 @@ export const Callout: FC<CalloutProps> = ({ icon, children, intention = 'subtle'
           {icon}
         </span>
       )}
-      <Text id={descriptionId} size="r" weight="regular" typeface="sansSerif">
+      <Text id={descriptionId} size="r" weight="regular" typeface="sansSerif" className={fsx(`w-full break-words`)}>
         {children}
       </Text>
     </Text>


### PR DESCRIPTION
## チケット

- Close #1383 

## 実装内容

- Calloutに `w-full h-fit` を追加
  - flex内に置かれたときに意図しないレイアウト崩れを防ぐため

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
