### PR TITLE
fix(Button): ローディングアイコンの色とサイズを修正

### DIFF
--- a/.changeset/itchy-rice-allow.md
+++ b/.changeset/itchy-rice-allow.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(Button): ローディングアイコンの色とサイズを修正

--- a/packages/for-ui/src/button/Button.tsx
+++ b/packages/for-ui/src/button/Button.tsx
@@ -236,7 +236,11 @@ const _Button = <As extends ElementType = 'button'>({
       {endIcon}
       {loading && (
         <div className={fsx(`absolute inset-0 grid h-full w-full place-items-center`)}>
-          <Loader className={fsx(`[&:is(svg)]:fill-shade-dark-default [&:is(svg)]:h-6 [&:is(svg)]:w-6`)} />
+          <Loader
+            className={fsx(
+              `[&:is(svg):is(svg)]:fill-shade-dark-default [&:is(svg):is(svg)]:h-6 [&:is(svg):is(svg)]:w-6`,
+            )}
+          />
         </div>
       )}
     </MuiButton>


### PR DESCRIPTION
## チケット

- Close #1334 

## 実装内容

- Buttonのローディングアイコンの色とサイズを修正

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|    <img width="1496" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/2aa358ab-0497-4671-8af1-466e2fa2880d">    |    <img width="1496" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/7144570e-8629-429a-924e-a479d8b58945">    |

## 相談内容(あれば)

-
