### PR TITLE
fix(Pagination): デザイン修正

### DIFF
--- a/.changeset/great-suns-look.md
+++ b/.changeset/great-suns-look.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(Pagination): デザイン修正

--- a/packages/for-ui/src/table/Table.stories.tsx
+++ b/packages/for-ui/src/table/Table.stories.tsx
@@ -10,6 +10,7 @@ import { PersonData, StaticPersonData } from '../utils/makeData';
 import { ColumnDef } from './ColumnDef';
 import { Table, TableBody, TableFrame, TableHead, TableRow } from './Table';
 import { TableCell } from './TableCell';
+import { Pagination } from './TablePagination';
 import { TableScroller } from './TableScroller';
 
 export default {
@@ -247,3 +248,5 @@ export const WithoutReactTable: Story = () => (
     </TableBody>
   </TableFrame>
 );
+
+export const _Pagination: Story = () => <Pagination total={100} defaultPage={50} />;

--- a/packages/for-ui/src/table/Table.tsx
+++ b/packages/for-ui/src/table/Table.tsx
@@ -76,7 +76,6 @@ export const Table = <T extends RowData>({
   defaultPage = 1,
   onChangePage,
 }: TableProps<T>) => {
-  // const { data, disablePagination, defaultSortColumn, onSelectRow, onSelectRows, onRowClick, rowRenderer } = props;
   const [sorting, setSorting] = useState<SortingState>(defaultSortColumn ? [defaultSortColumn] : []);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const prevRowSelection = useRef<RowSelectionState>({});
@@ -204,8 +203,8 @@ export const Table = <T extends RowData>({
   }, [table, pageSize]);
 
   return (
-    <div className="flex flex-col gap-2">
-      <TableFrame className={className} id={tableId}>
+    <div className={fsx(`flex flex-col gap-2`, className)}>
+      <TableFrame id={tableId}>
         <TableHead>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id} className="table-row">
@@ -245,7 +244,7 @@ export const Table = <T extends RowData>({
         </TableBody>
       </TableFrame>
       {!disablePagination && (
-        <div className="flex w-full justify-center">
+        <div className={fsx(`flex w-full justify-center`)}>
           <TablePagination
             page={page}
             defaultPage={defaultPage}

--- a/packages/for-ui/src/table/Table.tsx
+++ b/packages/for-ui/src/table/Table.tsx
@@ -1,4 +1,15 @@
-import { FC, forwardRef, Fragment, MouseEvent, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  FC,
+  forwardRef,
+  Fragment,
+  MouseEvent,
+  useCallback,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   ColumnDef,
   ColumnSort,
@@ -69,6 +80,7 @@ export const Table = <T extends RowData>({
   const [sorting, setSorting] = useState<SortingState>(defaultSortColumn ? [defaultSortColumn] : []);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const prevRowSelection = useRef<RowSelectionState>({});
+  const tableId = useId();
 
   const onRowSelectionChange: OnChangeFn<RowSelectionState> = useCallback(
     (updater) => {
@@ -192,8 +204,8 @@ export const Table = <T extends RowData>({
   }, [table, pageSize]);
 
   return (
-    <Fragment>
-      <TableFrame className={className}>
+    <div className="flex flex-col gap-2">
+      <TableFrame className={className} id={tableId}>
         <TableHead>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id} className="table-row">
@@ -233,9 +245,17 @@ export const Table = <T extends RowData>({
         </TableBody>
       </TableFrame>
       {!disablePagination && (
-        <TablePagination page={page} defaultPage={defaultPage} onChangePagination={onChangePage} table={table} />
+        <div className="flex w-full justify-center">
+          <TablePagination
+            page={page}
+            defaultPage={defaultPage}
+            onChangePage={onChangePage}
+            table={table}
+            aria-controls={tableId}
+          />
+        </div>
       )}
-    </Fragment>
+    </div>
   );
 };
 

--- a/packages/for-ui/src/table/TablePagination.test.tsx
+++ b/packages/for-ui/src/table/TablePagination.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Pagination } from './TablePagination';
+
+describe('Pagination', () => {
+  it('is rendered with first, last, prev, next, and current page buttons', async () => {
+    render(<Pagination total={100} page={50} />);
+    expect(screen.queryByRole('button', { name: '最初のページへ移動' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '最後のページへ移動' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '前のページへ移動' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '次のページへ移動' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'ページ1へ移動' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'ページ100へ移動' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '現在のページ ページ50' })).toBeInTheDocument();
+  });
+  it('calls event handlers when first page button is clicked', async () => {
+    const user = userEvent.setup();
+    const onChangePage = vi.fn((page: number) => page);
+    const onClickFirstPageButton = vi.fn();
+    render(<Pagination total={100} defaultPage={50} onChangePage={onChangePage} onClickFirstPageButton={onClickFirstPageButton} />);
+    await user.click(screen.getByRole('button', { name: '最初のページへ移動' }))
+    expect(onChangePage).toHaveBeenCalledOnce();
+    expect(onChangePage).toHaveLastReturnedWith(1);
+    expect(onClickFirstPageButton).toHaveBeenCalledOnce();
+  })
+  it('calls event handlers when last page button is clicked', async () => {
+    const user = userEvent.setup();
+    const onChangePage = vi.fn((page: number) => page);
+    const onClickLastPageButton = vi.fn();
+    render(<Pagination total={100} defaultPage={50} onChangePage={onChangePage} onClickLastPageButton={onClickLastPageButton} />);
+    await user.click(screen.getByRole('button', { name: '最後のページへ移動' }))
+    expect(onChangePage).toHaveBeenCalledOnce();
+    expect(onChangePage).toHaveLastReturnedWith(100);
+    expect(onClickLastPageButton).toHaveBeenCalledOnce();
+  })
+  it('calls event handlers when previous page button is clicked', async () => {
+    const user = userEvent.setup();
+    const onChangePage = vi.fn((page: number) => page);
+    const onClickPreviousPageButton = vi.fn();
+    render(<Pagination total={100} defaultPage={50} onChangePage={onChangePage} onClickPreviousPageButton={onClickPreviousPageButton} />);
+    await user.click(screen.getByRole('button', { name: '前のページへ移動' }))
+    expect(onChangePage).toHaveBeenCalledOnce();
+    expect(onChangePage).toHaveLastReturnedWith(49);
+    expect(onClickPreviousPageButton).toHaveBeenCalledOnce();
+  })
+  it('calls event handlers when next page button is clicked', async () => {
+    const user = userEvent.setup();
+    const onChangePage = vi.fn((page: number) => page);
+    const onClickNextPageButton = vi.fn();
+    render(<Pagination total={100} defaultPage={50} onChangePage={onChangePage} onClickNextPageButton={onClickNextPageButton} />);
+    await user.click(screen.getByRole('button', { name: '次のページへ移動' }))
+    expect(onChangePage).toHaveBeenCalledOnce();
+    expect(onChangePage).toHaveLastReturnedWith(51);
+    expect(onClickNextPageButton).toHaveBeenCalledOnce();
+  })
+})

--- a/packages/for-ui/src/table/TablePagination.test.tsx
+++ b/packages/for-ui/src/table/TablePagination.test.tsx
@@ -18,40 +18,68 @@ describe('Pagination', () => {
     const user = userEvent.setup();
     const onChangePage = vi.fn((page: number) => page);
     const onClickFirstPageButton = vi.fn();
-    render(<Pagination total={100} defaultPage={50} onChangePage={onChangePage} onClickFirstPageButton={onClickFirstPageButton} />);
-    await user.click(screen.getByRole('button', { name: '最初のページへ移動' }))
+    render(
+      <Pagination
+        total={100}
+        defaultPage={50}
+        onChangePage={onChangePage}
+        onClickFirstPageButton={onClickFirstPageButton}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: '最初のページへ移動' }));
     expect(onChangePage).toHaveBeenCalledOnce();
     expect(onChangePage).toHaveLastReturnedWith(1);
     expect(onClickFirstPageButton).toHaveBeenCalledOnce();
-  })
+  });
   it('calls event handlers when last page button is clicked', async () => {
     const user = userEvent.setup();
     const onChangePage = vi.fn((page: number) => page);
     const onClickLastPageButton = vi.fn();
-    render(<Pagination total={100} defaultPage={50} onChangePage={onChangePage} onClickLastPageButton={onClickLastPageButton} />);
-    await user.click(screen.getByRole('button', { name: '最後のページへ移動' }))
+    render(
+      <Pagination
+        total={100}
+        defaultPage={50}
+        onChangePage={onChangePage}
+        onClickLastPageButton={onClickLastPageButton}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: '最後のページへ移動' }));
     expect(onChangePage).toHaveBeenCalledOnce();
     expect(onChangePage).toHaveLastReturnedWith(100);
     expect(onClickLastPageButton).toHaveBeenCalledOnce();
-  })
+  });
   it('calls event handlers when previous page button is clicked', async () => {
     const user = userEvent.setup();
     const onChangePage = vi.fn((page: number) => page);
     const onClickPreviousPageButton = vi.fn();
-    render(<Pagination total={100} defaultPage={50} onChangePage={onChangePage} onClickPreviousPageButton={onClickPreviousPageButton} />);
-    await user.click(screen.getByRole('button', { name: '前のページへ移動' }))
+    render(
+      <Pagination
+        total={100}
+        defaultPage={50}
+        onChangePage={onChangePage}
+        onClickPreviousPageButton={onClickPreviousPageButton}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: '前のページへ移動' }));
     expect(onChangePage).toHaveBeenCalledOnce();
     expect(onChangePage).toHaveLastReturnedWith(49);
     expect(onClickPreviousPageButton).toHaveBeenCalledOnce();
-  })
+  });
   it('calls event handlers when next page button is clicked', async () => {
     const user = userEvent.setup();
     const onChangePage = vi.fn((page: number) => page);
     const onClickNextPageButton = vi.fn();
-    render(<Pagination total={100} defaultPage={50} onChangePage={onChangePage} onClickNextPageButton={onClickNextPageButton} />);
-    await user.click(screen.getByRole('button', { name: '次のページへ移動' }))
+    render(
+      <Pagination
+        total={100}
+        defaultPage={50}
+        onChangePage={onChangePage}
+        onClickNextPageButton={onClickNextPageButton}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: '次のページへ移動' }));
     expect(onChangePage).toHaveBeenCalledOnce();
     expect(onChangePage).toHaveLastReturnedWith(51);
     expect(onClickNextPageButton).toHaveBeenCalledOnce();
-  })
-})
+  });
+});

--- a/packages/for-ui/src/table/TablePagination.tsx
+++ b/packages/for-ui/src/table/TablePagination.tsx
@@ -1,48 +1,259 @@
-import Pagination from '@mui/material/Pagination';
+import { FC, ReactEventHandler } from 'react';
+import {
+  MdMoreHoriz,
+  MdOutlineChevronLeft,
+  MdOutlineChevronRight,
+  MdOutlineFirstPage,
+  MdOutlineLastPage,
+} from 'react-icons/md';
+import usePagination from '@mui/material/usePagination';
 import { RowData, Table } from '@tanstack/react-table';
+import { Button } from '../button';
+import { fsx } from '../system/fsx';
 
-export interface TablePaginationProps<T extends RowData> {
+export type TablePaginationProps<T extends RowData> = {
+  /**
+   * Paginationをつけるテーブル
+   */
   table: Table<T>;
+
+  /**
+   * 現在のページ数
+   */
   page?: number;
+
+  /**
+   * デフォルトのページ数
+   *
+   * page propを使っているときは無視されます。
+   */
   defaultPage?: number;
+
+  /**
+   * ページが変更されたときに呼ばれるコールバック
+   *
+   * @deprecated onChangePageをを使ってください。
+   */
   onChangePagination?: (page: number) => void;
-}
+
+  /**
+   * ページが変更されたときに呼ばれるコールバック
+   */
+  onChangePage?: (page: number) => void;
+
+  /**
+   * ページネーションに設定するラベル
+   *
+   * どのテーブルに対応するのかを示唆する名前を設定するのが好ましいです。例: テーブルの名前が「アカウント一覧」なら "アカウント一覧のページ送り" のようにする
+   *
+   * @default ページ送り
+   */
+  'aria-label'?: string;
+
+  /**
+   * 操作する対象のテーブルのidを指定
+   */
+  'aria-controls'?: string;
+
+  className?: string;
+};
 
 export const TablePagination = <T extends RowData>({
   table,
   page,
   defaultPage = 1,
   onChangePagination,
+  onChangePage = onChangePagination,
+  ...props
 }: TablePaginationProps<T>) => {
   const { getPageCount, setPageIndex } = table;
 
-  const handleChange = (_: React.ChangeEvent<unknown>, p: number) => {
-    if (onChangePagination) {
-      onChangePagination(p);
-    }
-
+  const handleChange = (p: number) => {
+    onChangePage?.(p);
     if (!page) {
       setPageIndex(p - 1);
     }
   };
 
   return (
-    <div className="border-shade-light-default bg-shade-white-default flex items-center justify-between px-4 py-3 sm:px-6">
-      <div className="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
-        <div />
-        <div>
-          <Pagination
-            page={page}
-            defaultPage={defaultPage}
-            size="large"
-            shape="rounded"
-            count={getPageCount()}
-            showFirstButton
-            showLastButton
-            onChange={handleChange}
-          />
-        </div>
-      </div>
-    </div>
+    <Pagination total={getPageCount()} page={page} defaultPage={defaultPage} onChangePage={handleChange} {...props} />
+  );
+};
+
+type PaginationProps = {
+  /**
+   * 全てのページ数を指定
+   */
+  total: number;
+
+  /**
+   * 現在のページを指定
+   *
+   * pageかdefaultPageのどちらかは必須です。
+   */
+  page?: number;
+
+  /**
+   * デフォルトページを指定
+   *
+   * pageかdefaultPageのどちらかは必須です。
+   *
+   * page propが指定されていない場合、Paginationコンポーネントは内部でページの情報を持ちます。
+   */
+  defaultPage?: number;
+
+  /**
+   * ページ変更時に呼ばれるコールバックを指定
+   */
+  onChangePage?: (page: number) => void;
+
+  /**
+   * ページネーションに設定するラベル
+   *
+   * どのテーブルに対応するのかを示唆する名前を設定するのが好ましいです。例: テーブルの名前が「アカウント一覧」なら "アカウント一覧のページ送り" のようにする
+   *
+   * @default ページ送り
+   */
+  'aria-label'?: string;
+
+  /**
+   * 操作する対象のテーブルのidを指定
+   */
+  'aria-controls'?: string;
+
+  /**
+   * 前のページを表示ボタンがクリックされたときのコールバックを指定
+   */
+  onClickPreviousPageButton?: ReactEventHandler<HTMLButtonElement>;
+
+  /**
+   * 次のページを表示ボタンがクリックされたときのコールバックを指定
+   */
+  onClickNextPageButton?: ReactEventHandler<HTMLButtonElement>;
+
+  /**
+   * 最初のページを表示ボタンがクリックされたときのコールバックを指定
+   */
+  onClickFirstPageButton?: ReactEventHandler<HTMLButtonElement>;
+
+  /**
+   * 最後のページを表示ボタンがクリックされたときのコールバックを指定
+   */
+  onClickLastPageButton?: ReactEventHandler<HTMLButtonElement>;
+
+  className?: string;
+};
+
+export const Pagination: FC<PaginationProps> = ({
+  defaultPage,
+  total,
+  page,
+  onChangePage,
+  onClickFirstPageButton,
+  onClickLastPageButton,
+  onClickNextPageButton,
+  onClickPreviousPageButton,
+  className,
+  ...props
+}) => {
+  const { items } = usePagination({
+    page,
+    defaultPage,
+    count: total,
+    showFirstButton: true,
+    showLastButton: true,
+    siblingCount: 2,
+    onChange: (_, page) => {
+      onChangePage?.(page);
+    },
+  });
+  return (
+    <nav aria-label="ページ送り" className={fsx(className)} {...props}>
+      <ul className={fsx(`flex items-center gap-2`)}>
+        {items.map(({ type, page, selected, onClick, ...item }, index) => (
+          <li key={index}>
+            {
+              {
+                'start-ellipsis': <MdMoreHoriz className={fsx(`fill-shade-medium-default`)} />,
+                'end-ellipsis': <MdMoreHoriz className={fsx(`fill-shade-medium-default`)} />,
+                first: (
+                  <Button
+                    aria-label="最初のページへ移動"
+                    intention="primary"
+                    variant="text"
+                    size="small"
+                    onClick={(e) => {
+                      onClickFirstPageButton?.(e);
+                      onClick(e);
+                    }}
+                    {...item}
+                  >
+                    <MdOutlineFirstPage aria-hidden />
+                  </Button>
+                ),
+                last: (
+                  <Button
+                    aria-label="最後のページへ移動"
+                    intention="primary"
+                    variant="text"
+                    size="small"
+                    onClick={(e) => {
+                      onClickLastPageButton?.(e);
+                      onClick(e);
+                    }}
+                    {...item}
+                  >
+                    <MdOutlineLastPage />
+                  </Button>
+                ),
+                previous: (
+                  <Button
+                    aria-label="前のページへ移動"
+                    intention="primary"
+                    variant="text"
+                    size="small"
+                    onClick={(e) => {
+                      onClickPreviousPageButton?.(e);
+                      onClick(e);
+                    }}
+                    {...item}
+                  >
+                    <MdOutlineChevronLeft />
+                  </Button>
+                ),
+                next: (
+                  <Button
+                    aria-label="次のページへ移動"
+                    intention="primary"
+                    variant="text"
+                    size="small"
+                    onClick={(e) => {
+                      onClickNextPageButton?.(e);
+                      onClick(e);
+                    }}
+                    {...item}
+                  >
+                    <MdOutlineChevronRight />
+                  </Button>
+                ),
+                page: (
+                  <Button
+                    aria-label={selected ? `現在のページ ページ${page}` : `ページ${page}へ移動`}
+                    aria-current={selected ? true : undefined}
+                    variant={selected ? 'filled' : 'outlined'}
+                    intention={selected ? 'primary' : 'subtle'}
+                    size="small"
+                    onClick={onClick}
+                    {...item}
+                  >
+                    {page?.toString()}
+                  </Button>
+                ),
+              }[type]
+            }
+          </li>
+        ))}
+      </ul>
+    </nav>
   );
 };

--- a/packages/for-ui/src/textArea/TextArea.test.tsx
+++ b/packages/for-ui/src/textArea/TextArea.test.tsx
@@ -66,7 +66,7 @@ World`);
   });
   it('with error and helperText shows error message', async () => {
     render(<TextArea label="TextArea" error helperText="Something wrong" />);
-    expect(screen.getByRole('textbox', { name: 'TextArea' })).toHaveErrorMessage('Something wrong');
+    expect(screen.getByRole('textbox', { name: 'TextArea' })).toHaveAccessibleErrorMessage('Something wrong');
   });
 });
 

--- a/packages/for-ui/src/textField/TextField.test.tsx
+++ b/packages/for-ui/src/textField/TextField.test.tsx
@@ -79,7 +79,7 @@ World`,
   });
   it('with error and helperText shows error message', async () => {
     render(<TextField label="TextField" error helperText="Something wrong" />);
-    expect(screen.getByRole('textbox', { name: 'TextField' })).toHaveErrorMessage('Something wrong');
+    expect(screen.getByRole('textbox', { name: 'TextField' })).toHaveAccessibleErrorMessage('Something wrong');
   });
 });
 


### PR DESCRIPTION
## チケット

- Close #1325 

## 実装内容

- Paginationコンポーネントを新たに[デザイン](https://www.figma.com/file/FXAVXugpz9S1j3k8Lcs6au/For-UI-v1.1.9?type=design&node-id=315-9187&mode=design&t=ib5S9Jzr609PMMSN-11)に合わせて作成
  - `inputtable={true}`は未実装
- TablePaginationからPaginationを使うように修正
  - onChangePaginationをonChangePageに修正: Paginationはページ送りという意味なのでPageのほうが好ましい
- Tableの`disablePagination={false}`のときのデザインを更新
  - 中央揃えに変更
  - Pagination自体にはmargin等をもたせたくないのでそれに合わせた更新

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|   <img width="1386" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/25fcfa0b-5cf8-4b9d-bb6d-311c3e95ca87">     |    <img width="1387" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/4b5149f3-8a7b-4461-a86e-f503e7daf3f4">    |

## 相談内容(あれば)

-
