### PR TITLE
fix(Button): childrenがnumberのときも構造上テキストとして扱うよう修正

### DIFF
--- a/.changeset/forty-parents-fix.md
+++ b/.changeset/forty-parents-fix.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(Button): childrenがnumberのときも構造上テキストとして扱うよう修正

--- a/packages/for-ui/src/button/Button.tsx
+++ b/packages/for-ui/src/button/Button.tsx
@@ -102,10 +102,14 @@ export type ButtonProps<As extends ElementType = 'button'> = MuiButtonProps<As> 
 const extractText = (root: ReactNode): string => {
   let ret = '';
   walkChildren(root, (node) => {
-    if (typeof node !== 'string') {
+    if (typeof node === 'string') {
+      ret += node;
       return;
     }
-    ret += node;
+    if (typeof node === 'number') {
+      ret += `${node}`;
+      return;
+    }
   });
   return ret;
 };


### PR DESCRIPTION
## チケット

- Close #1405 

## 実装内容

- Buttonの中で構造を判定するのに使っている `extractText` がchildrenがnumberのときに無視していたのを修正

## スクリーンショット

わかりにくいですがtextのときのpaddingが左右に広めに取られるようになっているのを確認しました

| 変更前 | 変更後 |
| ------ | ------ |
|    ![](https://user-images.githubusercontent.com/8467289/255100085-26c5ac87-1c8b-4205-91fd-18ef93d0ee15.png)    |     ![](https://user-images.githubusercontent.com/8467289/255100175-6a833330-dcf9-4a93-aeba-12363a3d0f48.png)   |

## 相談内容(あれば)

-
