### PR TITLE
feat(Table): ローディングを追加

### DIFF
--- a/.changeset/perfect-ties-taste.md
+++ b/.changeset/perfect-ties-taste.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+feat(Table): ローディングを追加

--- a/packages/for-ui/src/table/ColumnDef.ts
+++ b/packages/for-ui/src/table/ColumnDef.ts
@@ -1,3 +1,1 @@
-import type { ColumnDef } from '@tanstack/react-table';
-
-export { ColumnDef };
+export type { ColumnDef } from '@tanstack/react-table';

--- a/packages/for-ui/src/table/Table.stories.tsx
+++ b/packages/for-ui/src/table/Table.stories.tsx
@@ -46,7 +46,7 @@ const columns: ColumnDef<PersonData, ReactNode>[] = [
 
 export const Base: Story = () => <Table<PersonData> columns={columns} data={StaticPersonData} />;
 
-export const Loading: Story = () => <Table<PersonData> loading loadingRows={10} columns={columns} />;
+export const Loading: Story = () => <Table<PersonData> loading loadingRows={20} columns={columns} />;
 
 export const LoadingWithSelect: Story = () => (
   <Table<PersonData>

--- a/packages/for-ui/src/table/Table.stories.tsx
+++ b/packages/for-ui/src/table/Table.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { MdMoreVert, MdOutlineDelete, MdOutlineEdit } from 'react-icons/md';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { Badge } from '../badge';
@@ -18,11 +18,13 @@ export default {
   component: Table,
 } as Meta;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const columns: ColumnDef<PersonData, any>[] = [
+const columns: ColumnDef<PersonData, ReactNode>[] = [
   {
     header: 'ID',
     accessorKey: 'id',
+    meta: {
+      width: '16px',
+    },
     cell: (cell) => <TableCell>{cell.renderValue()}</TableCell>,
   },
   {
@@ -43,6 +45,18 @@ const columns: ColumnDef<PersonData, any>[] = [
 ];
 
 export const Base: Story = () => <Table<PersonData> columns={columns} data={StaticPersonData} />;
+
+export const Loading: Story = () => <Table<PersonData> loading loadingRows={10} columns={columns} />;
+
+export const LoadingWithSelect: Story = () => (
+  <Table<PersonData>
+    loading
+    loadingRows={10}
+    columns={columns}
+    getRowId={(row) => row.id.toString()}
+    onSelectRow={(row) => console.info('Selected row: ', row)}
+  />
+);
 
 export const WithSelect: Story = () => (
   <Table<PersonData>

--- a/packages/for-ui/src/table/Table.tsx
+++ b/packages/for-ui/src/table/Table.tsx
@@ -11,7 +11,6 @@ import {
   useState,
 } from 'react';
 import {
-  ColumnDef,
   ColumnSort,
   flexRender,
   getCoreRowModel,
@@ -28,12 +27,14 @@ import {
 } from '@tanstack/react-table';
 import { Checkbox } from '../checkbox';
 import { Radio } from '../radio';
+import { Skeleton } from '../skeleton';
 import { fsx } from '../system/fsx';
 import { Text } from '../text';
+import { ColumnDef } from './ColumnDef';
 import { SortableTableCellHead, TableCell } from './TableCell';
 import { TablePagination } from './TablePagination';
 
-export type TableProps<T extends RowData> = Pick<TableOptions<T>, 'data' | 'columns' | 'getRowId'> & {
+export type TableProps<T extends RowData> = Pick<TableOptions<T>, 'columns' | 'getRowId'> & {
   disablePagination?: boolean | undefined;
   defaultSortColumn?: ColumnSort;
   /** onRowClick is called when each row is clicked regardless of the type of table (selectable or not) */
@@ -46,6 +47,7 @@ export type TableProps<T extends RowData> = Pick<TableOptions<T>, 'data' | 'colu
   pageSize?: number;
   defaultPage?: number;
   onChangePage?: (page: number) => void;
+  loading?: boolean;
 } & (
     | {
         /** If wanting to use selectable table, specify _onSelectRow_ or _onSelectRows_ exclusively */
@@ -57,7 +59,103 @@ export type TableProps<T extends RowData> = Pick<TableOptions<T>, 'data' | 'colu
         /** If wanting to use selectable table, specify _onSelectRow_ or _onSelectRows_ exclusively */
         onSelectRows?: ((ids: string[]) => void) | undefined;
       }
+  ) &
+  (
+    | {
+        loading?: false | undefined;
+        loadingRows?: never;
+        data: TableOptions<T>['data'];
+      }
+    | {
+        loading: true;
+        loadingRows: number;
+        data?: never;
+      }
   );
+
+const getSelectColumn = <T extends RowData>({
+  id,
+  multiple,
+  loading,
+  onSelectRow,
+}: {
+  id: string;
+  multiple?: boolean;
+  loading?: boolean;
+  onSelectRow?: (row: RowType<T>) => void;
+}): ColumnDef<T> => {
+  return {
+    id,
+    meta: {
+      minWidth: '20px',
+      width: '20px',
+      maxWidth: '20px',
+    },
+    header: ({ table }) => (
+      <Fragment>
+        {multiple && (
+          <Checkbox
+            label={
+              <Text aria-hidden={false} className={fsx(`hidden`)}>
+                すべての行を選択
+              </Text>
+            }
+            disabled={loading}
+            className={fsx(`flex`)}
+            checked={table.getIsAllRowsSelected()}
+            indeterminate={!table.getIsAllRowsSelected() && table.getIsSomeRowsSelected()}
+            onChange={table.getToggleAllRowsSelectedHandler()}
+          />
+        )}
+      </Fragment>
+    ),
+    cell: ({ row }) => (
+      <TableCell as="th" scope="row">
+        {multiple ? (
+          <Checkbox
+            label={
+              <Text aria-hidden={false} className={fsx(`hidden`)}>
+                行を選択
+              </Text>
+            }
+            disabled={loading}
+            className={fsx(`flex`)}
+            checked={row.getIsSelected()}
+            onClick={(e) => {
+              onSelectRow?.(row);
+              e.stopPropagation();
+            }}
+          />
+        ) : (
+          <Radio
+            label={
+              <Text aria-hidden={false} className={fsx(`hidden`)}>
+                行を選択
+              </Text>
+            }
+            disabled={loading}
+            className={fsx(`flex`)}
+            checked={row.getIsSelected()}
+            onClick={(e) => {
+              onSelectRow?.(row);
+              e.stopPropagation();
+            }}
+          />
+        )}
+      </TableCell>
+    ),
+  };
+};
+
+const makeColumnsLoading = <T extends RowData>(columns: ColumnDef<T>[]) =>
+  columns.map((column) => ({
+    ...column,
+    cell: () => (
+      <TableCell>
+        <Skeleton variant="rounded" loading className="flex h-6 w-full" />
+      </TableCell>
+    ),
+  }));
 
 export const Table = <T extends RowData>({
   data,
@@ -68,18 +166,22 @@ export const Table = <T extends RowData>({
   onRowClick,
   rowRenderer,
   getRowId,
-  columns,
+  columns: passedColumns,
   pageCount,
   pageSize = 20,
   className,
   page,
   defaultPage = 1,
   onChangePage,
+  loading,
+  loadingRows,
 }: TableProps<T>) => {
   const [sorting, setSorting] = useState<SortingState>(defaultSortColumn ? [defaultSortColumn] : []);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const prevRowSelection = useRef<RowSelectionState>({});
   const tableId = useId();
+
+  const selectable = !!(onSelectRow || onSelectRows);
 
   const onRowSelectionChange: OnChangeFn<RowSelectionState> = useCallback(
     (updater) => {
@@ -110,91 +212,45 @@ export const Table = <T extends RowData>({
 
   const RowComponent: FC<RowProps<T>> = rowRenderer || Row;
 
-  const selectableColumns = useMemo(() => {
-    // Not selectable table
-    if (!(onSelectRow || onSelectRows)) {
-      return columns;
-    }
+  const loadingDummyData = Array(loadingRows).fill(
+    Object.fromEntries(
+      passedColumns.map((column) => [column.id || ('accessorKey' in column && column.accessorKey), '']),
+    ),
+  );
 
-    const selectColumn: ColumnDef<T> = {
-      // FIXME: use useId instead
-      id: 'select',
-      meta: {
-        minWidth: '20px',
-        width: '20px',
-        maxWidth: '20px',
-      },
-      header: ({ table }) => (
-        <Fragment>
-          {!!onSelectRows && (
-            <Checkbox
-              label={
-                <Text aria-hidden={false} className={fsx(`hidden`)}>
-                  すべての行を選択
-                </Text>
-              }
-              className={fsx(`flex`)}
-              checked={table.getIsAllRowsSelected()}
-              indeterminate={!table.getIsAllRowsSelected() && table.getIsSomeRowsSelected()}
-              onChange={table.getToggleAllRowsSelectedHandler()}
-            />
-          )}
-        </Fragment>
-      ),
-      cell: ({ row }) => (
-        <TableCell as="th" scope="row">
-          {!!onSelectRows && (
-            <Checkbox
-              label={
-                <Text aria-hidden={false} className={fsx(`hidden`)}>
-                  行を選択
-                </Text>
-              }
-              className={fsx(`flex`)}
-              checked={row.getIsSelected()}
-              onClick={(e) => {
-                selectRow(row);
-                e.stopPropagation();
-              }}
-            />
-          )}
-          {!!onSelectRow && (
-            <Radio
-              label={
-                <Text aria-hidden={false} className={fsx(`hidden`)}>
-                  行を選択
-                </Text>
-              }
-              className={fsx(`flex`)}
-              checked={row.getIsSelected()}
-              onClick={(e) => {
-                selectRow(row);
-                e.stopPropagation();
-              }}
-            />
-          )}
-        </TableCell>
-      ),
-    };
-    return [selectColumn, ...columns];
-  }, [onSelectRow, onSelectRows, selectRow, columns]);
+  const columns = useMemo(() => {
+    if (!selectable && !loading) {
+      return passedColumns;
+    }
+    const cols = loading ? makeColumnsLoading(passedColumns) : passedColumns;
+    if (!selectable) {
+      return cols;
+    }
+    const selectColumn = getSelectColumn({
+      id: `${tableId}-select`,
+      multiple: !!onSelectRows,
+      loading,
+      onSelectRow: selectRow,
+    });
+    return [selectColumn, ...cols];
+  }, [tableId, onSelectRows, loading, selectRow, passedColumns, selectable]);
 
   const table = useReactTable({
-    data,
-    columns: selectableColumns,
+    data: loading ? loadingDummyData : data,
+    columns,
     pageCount: disablePagination ? undefined : pageCount,
     state: {
       sorting,
       rowSelection,
     },
     getRowId,
-    onRowSelectionChange,
+    onRowSelectionChange: loading ? undefined : onRowSelectionChange,
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: !disablePagination ? getPaginationRowModel() : undefined,
-    enableRowSelection: !!(onSelectRow || onSelectRows),
+    enableRowSelection: selectable,
     enableMultiRowSelection: !!onSelectRows,
   });
 
@@ -204,7 +260,7 @@ export const Table = <T extends RowData>({
 
   return (
     <div className={fsx(`flex flex-col gap-2`, className)}>
-      <TableFrame id={tableId}>
+      <TableFrame id={tableId} aria-busy={loading}>
         <TableHead>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id} className="table-row">
@@ -212,6 +268,7 @@ export const Table = <T extends RowData>({
                 <SortableTableCellHead
                   key={header.id}
                   scope="col"
+                  disabled={loading}
                   nextSortingOrder={header.column.getNextSortingOrder()}
                   sortable={header.column.getCanSort()}
                   sorted={header.column.getIsSorted()}
@@ -231,7 +288,7 @@ export const Table = <T extends RowData>({
             <RowComponent
               key={row.id}
               row={row}
-              selectable={!!(onSelectRow || onSelectRows)}
+              selectable={selectable}
               onClick={
                 (onSelectRow || onSelectRows || onRowClick) &&
                 ((e, row) => {
@@ -246,6 +303,7 @@ export const Table = <T extends RowData>({
       {!disablePagination && (
         <div className={fsx(`flex w-full justify-center`)}>
           <TablePagination
+            disabled={loading}
             page={page}
             defaultPage={defaultPage}
             onChangePage={onChangePage}
@@ -262,7 +320,9 @@ export const TableFrame = forwardRef<HTMLTableElement, JSX.IntrinsicElements['ta
   ({ className, ...props }, ref) => (
     <div className={fsx(`border-shade-light-default h-full w-full overflow-auto rounded border`, className)}>
       <table
-        className={fsx(`ring-shade-light-default w-full border-separate border-spacing-0 ring-1`)}
+        className={fsx(
+          `ring-shade-light-default w-full border-separate border-spacing-0 ring-1 aria-[busy=true]:pointer-events-none`,
+        )}
         ref={ref}
         {...props}
       />
@@ -303,6 +363,7 @@ export const TableRow = forwardRef<HTMLTableRowElement, JSX.IntrinsicElements['t
 export type RowProps<T extends RowData> = {
   row: RowType<T>;
   selectable: boolean;
+  clickable?: boolean;
   onClick?: (e: MouseEvent<HTMLTableRowElement>, row: RowType<T>) => void;
   className?: string;
 };

--- a/packages/for-ui/src/table/Table.tsx
+++ b/packages/for-ui/src/table/Table.tsx
@@ -47,7 +47,6 @@ export type TableProps<T extends RowData> = Pick<TableOptions<T>, 'columns' | 'g
   pageSize?: number;
   defaultPage?: number;
   onChangePage?: (page: number) => void;
-  loading?: boolean;
 } & (
     | {
         /** If wanting to use selectable table, specify _onSelectRow_ or _onSelectRows_ exclusively */
@@ -62,12 +61,34 @@ export type TableProps<T extends RowData> = Pick<TableOptions<T>, 'columns' | 'g
   ) &
   (
     | {
+        /**
+         * 読み込み中であることを示す時に指定
+         *
+         * @default false
+         */
         loading?: false | undefined;
+
+        /**
+         * 読み込み中であることを示す時にスケルトンローディングで表示する行数を指定
+         *
+         * @default 10
+         */
         loadingRows?: never;
         data: TableOptions<T>['data'];
       }
     | {
+        /**
+         * 読み込み中であることを示す時に指定
+         *
+         * @default false
+         */
         loading: true;
+
+        /**
+         * 読み込み中であることを示す時にスケルトンローディングで表示する行数を指定
+         *
+         * @default 10
+         */
         loadingRows: number;
         data?: never;
       }
@@ -174,7 +195,7 @@ export const Table = <T extends RowData>({
   defaultPage = 1,
   onChangePage,
   loading,
-  loadingRows,
+  loadingRows = 10,
 }: TableProps<T>) => {
   const [sorting, setSorting] = useState<SortingState>(defaultSortColumn ? [defaultSortColumn] : []);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});

--- a/packages/for-ui/src/table/TableCell.tsx
+++ b/packages/for-ui/src/table/TableCell.tsx
@@ -44,9 +44,10 @@ export const SortableTableCellHead: FC<
     sorted: false | 'asc' | 'desc';
     nextSortingOrder: false | 'asc' | 'desc';
     children: ReactNode;
+    disabled?: boolean;
     onClick?: HTMLAttributes<HTMLButtonElement>['onClick'];
   }
-> = ({ sortable, sorted, nextSortingOrder, onClick, children, ...rest }) => (
+> = ({ sortable, sorted, nextSortingOrder, onClick, disabled, children, ...rest }) => (
   <TableCell
     as="th"
     aria-sort={sorted ? ({ asc: 'ascending', desc: 'descending' } as const)[sorted] : undefined}
@@ -55,6 +56,7 @@ export const SortableTableCellHead: FC<
   >
     {sortable ? (
       <button
+        disabled={disabled}
         onClick={onClick}
         className={fsx(
           `hover:bg-shade-light-hover focus-visible:bg-shade-light-hover group flex w-full items-center gap-1 px-3 py-1 focus-visible:outline-none`,

--- a/packages/for-ui/src/table/TablePagination.tsx
+++ b/packages/for-ui/src/table/TablePagination.tsx
@@ -55,6 +55,8 @@ export type TablePaginationProps<T extends RowData> = {
    */
   'aria-controls'?: string;
 
+  disabled?: boolean;
+
   className?: string;
 };
 
@@ -141,6 +143,8 @@ type PaginationProps = {
    */
   onClickLastPageButton?: ReactEventHandler<HTMLButtonElement>;
 
+  disabled?: boolean;
+
   className?: string;
 };
 
@@ -153,6 +157,7 @@ export const Pagination: FC<PaginationProps> = ({
   onClickLastPageButton,
   onClickNextPageButton,
   onClickPreviousPageButton,
+  disabled = false,
   className,
   ...props
 }) => {
@@ -163,6 +168,7 @@ export const Pagination: FC<PaginationProps> = ({
     showFirstButton: true,
     showLastButton: true,
     siblingCount: 2,
+    disabled,
     onChange: (_, page) => {
       onChangePage?.(page);
     },


### PR DESCRIPTION
## チケット

- Close #1485 

## 実装内容

- Tableにスケルトンローディングを追加
  - `loading` prop と `loadingRows` propを追加

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|   なし     |        <img width="1408" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/fce26ff9-80f2-45d1-af20-1f4bf98fee17"> |

## 相談内容(あれば)

-
