### PR TITLE
fix(Table): `default` prefixを`selectedRow`, `selectedRows` に付与

### DIFF
--- a/.changeset/lucky-gifts-cover.md
+++ b/.changeset/lucky-gifts-cover.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+Fix/selectable table add default prefix@1499

--- a/packages/for-ui/src/table/Table.stories.tsx
+++ b/packages/for-ui/src/table/Table.stories.tsx
@@ -49,7 +49,7 @@ export const WithSelect: Story = () => (
     columns={columns}
     data={StaticPersonData}
     getRowId={(row) => row.id.toString()}
-    selectedRow="2"
+    defaultSelectedRow="2"
     onSelectRow={(row) => console.info('Selected row: ', row)}
   />
 );
@@ -59,7 +59,7 @@ export const WithSelectMultiple: Story = () => (
     columns={columns}
     data={StaticPersonData}
     getRowId={(row) => row.id.toString()}
-    selectedRows={['2', '3', '4']}
+    defaultSelectedRows={['2', '3', '4']}
     onSelectRows={(rows) => console.info('Selected rows: ', rows)}
   />
 );


### PR DESCRIPTION
## チケット

- Close #1499 

## 実装内容

- `selectedRow`, `selectedRows` propはuncontrolledなpropなので `default` prefixつきに変更

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
