### PR TITLE
fix(Menu): MenuItemの高さが小さい画面で崩れるのを修正

### DIFF
--- a/.changeset/thirty-tools-reply.md
+++ b/.changeset/thirty-tools-reply.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(Menu): MenuItemの高さが小さい画面で崩れるのを修正

--- a/packages/for-ui/src/menu/MenuItem.tsx
+++ b/packages/for-ui/src/menu/MenuItem.tsx
@@ -44,7 +44,7 @@ export const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
       disabled={disabled}
       classes={{
         root: fsx([
-          `bg-shade-white-default text-r hover:bg-shade-white-hover focus-visible:bg-shade-white-active [&.Mui-focused]:bg-shade-white-active flex flex-row items-start gap-2 whitespace-nowrap px-4 py-1 font-sans`,
+          `bg-shade-white-default text-r hover:bg-shade-white-hover focus-visible:bg-shade-white-active [&.Mui-focused]:bg-shade-white-active flex min-h-[unset] flex-row items-start gap-2 whitespace-nowrap px-4 py-1 font-sans`,
           icon && `pl-2`,
           selected && `pr-2`,
           {


### PR DESCRIPTION
## **User description**
## チケット

- Close #1471

## 実装内容

- MenuItemのmin-heightをリセットするようにした

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|   <img width="598" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/919f21f4-2cad-409a-9565-9176acf033ed">     |    <img width="599" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/aede984f-7913-4e0e-ba63-ac2a4b81a178">    |

## 相談内容(あれば)

-


___

## **Type**
bug_fix


___

## **Description**
- Reset the minimum height of the `MenuItem` component to ensure it displays correctly in small window sizes.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MenuItem.tsx</strong><dd><code>Reset `MenuItem` Component's Minimum Height</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/for-ui/src/menu/MenuItem.tsx

<li>Added <code>min-h-[unset]</code> to the <code>MenuItem</code> component to reset its minimum <br>height.<br>


</details>
    

  </td>
  <td><a href="https://github.com/4-design/for-ui/pull/1549/files#diff-2118da7dbcb9825dc944464fa7718ffc6f18676b806fd37c6a6757b98b6901d0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

