### PR TITLE
fix(TextField): Mobile SafariでTextField type=dateの高さが潰れてしまうのを修正

### DIFF
--- a/.changeset/proud-bugs-stare.md
+++ b/.changeset/proud-bugs-stare.md
@@ -1,0 +1,5 @@
+---
+"@4design/for-ui": patch
+---
+
+fix(TextField): Mobile SafariでTextField type=dateの高さが潰れてしまうのを修正

--- a/packages/for-ui/src/textField/TextField.tsx
+++ b/packages/for-ui/src/textField/TextField.tsx
@@ -173,7 +173,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
                 `bg-shade-white-disabled placeholder:text-shade-light-default text-shade-light-disabled cursor-not-allowed [-webkit-text-fill-color:currentColor_!important]`,
               ),
               input: fsx([
-                `text-r text-shade-dark-default placeholder:text-shade-light-default h-auto grow p-0 font-sans placeholder:opacity-100 focus:shadow-none`,
+                `text-r text-shade-dark-default placeholder:text-shade-light-default h-6 grow p-0 font-sans placeholder:opacity-100 focus:shadow-none [&::-webkit-date-and-time-value]:text-start`,
                 {
                   large: [`px-2`, icon && `pl-1`],
                   medium: [`px-1`, icon && `pl-1`],


### PR DESCRIPTION
## **User description**
## チケット

- Close #1470 

## 実装内容

- Mobile SafariでTextField type=dateの高さが潰れてしまうのを修正

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|   <img width="509" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/27ce2465-c7a9-4934-9aae-560b867502b8">  <img width="509" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/d3d2114b-a437-41ec-9a97-493afac668ba">   |     <img width="509" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/54819828-6565-44ba-9bb6-b99f07f29030">  <img width="509" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/8b8d54f5-b638-4470-892b-4cc383a43824">  |

## 相談内容(あれば)

- Safariだと下の画像のようにテキストの位置がずれてしまうのだが、inputにflexをいれると今度はChrome等で表示が崩れるので一旦無視してます

<img width="1431" alt="image" src="https://github.com/4-design/for-ui/assets/8467289/2a1dc76f-26e4-470c-ad2e-ff66c0ac70cf">



___

## **Type**
bug_fix


___

## **Description**
- Fixed an issue where the height of `TextField` components with `type=date` was being crushed in Mobile Safari.
- Ensured proper text alignment in date input fields by adding a CSS rule.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TextField.tsx</strong><dd><code>Fix TextField Height Issue for Type Date on iOS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packages/for-ui/src/textField/TextField.tsx

<li>Adjusted the height of the <code>TextField</code> component for type=date to <br>prevent it from being crushed in Mobile Safari.<br> <li> Added a specific CSS rule <code>&::-webkit-date-and-time-value]:text-start</code> <br>to ensure proper text alignment in date input fields.<br>


</details>
    

  </td>
  <td><a href="https://github.com/4-design/for-ui/pull/1550/files#diff-7d085d075f1d51d57d6661012d2f60f35848c8cbca220df0d8c483ded7b11476">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

