### PR TITLE
fix: Radio, CheckboxのProps型を修正

### DIFF
--- a/packages/for-ui/src/checkbox/Checkbox.tsx
+++ b/packages/for-ui/src/checkbox/Checkbox.tsx
@@ -1,11 +1,11 @@
-import { FC, forwardRef, ReactNode } from 'react';
+import { FC, forwardRef, ReactNode, ComponentPropsWithRef } from 'react';
 import { MdCheck, MdRemove } from 'react-icons/md';
 import MuiCheckbox, { CheckboxProps as MuiCheckboxProps } from '@mui/material/Checkbox';
 import { fsx } from '../system/fsx';
 import { TextDefaultStyler } from '../system/TextDefaultStyler';
 import { Text } from '../text';
 
-export type CheckboxProps = MuiCheckboxProps & {
+type _CheckboxProps = MuiCheckboxProps & {
   label?: ReactNode;
   nopadding?: boolean;
   className?: string;
@@ -32,7 +32,7 @@ const Indicator: FC<{ state: 'default' | 'checked' | 'intermediate'; disabled: b
   </span>
 );
 
-export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+export const Checkbox = forwardRef<HTMLInputElement, _CheckboxProps>(
   ({ label, nopadding = false, disabled, className, ...rest }, ref) => (
     <Text as="label" className={fsx(`group inline-flex w-fit flex-row items-center gap-1`, className)}>
       <MuiCheckbox
@@ -58,3 +58,5 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     </Text>
   ),
 );
+
+export type CheckboxProps = ComponentPropsWithRef<typeof Checkbox>

--- a/packages/for-ui/src/radio/Radio.tsx
+++ b/packages/for-ui/src/radio/Radio.tsx
@@ -1,10 +1,10 @@
-import { FC, forwardRef, ReactNode } from 'react';
+import { ComponentPropsWithRef, FC, forwardRef, ReactNode } from 'react';
 import MuiRadio, { RadioProps as MuiRadioProps } from '@mui/material/Radio';
 import { fsx } from '../system/fsx';
 import { TextDefaultStyler } from '../system/TextDefaultStyler';
 import { Text } from '../text';
 
-export type RadioProps = Omit<MuiRadioProps, 'ref'> & {
+type _RadioProps = Omit<MuiRadioProps, 'ref'> & {
   label?: ReactNode;
   nopadding?: boolean;
   className?: string;
@@ -20,7 +20,7 @@ const Indicator: FC<{ checked: boolean; disabled: boolean }> = ({ checked, disab
   />
 );
 
-export const Radio = forwardRef<HTMLInputElement, RadioProps>(
+export const Radio = forwardRef<HTMLInputElement, _RadioProps>(
   ({ nopadding, label, value, disabled, className, ...rest }, ref) => (
     <Text as="label" className={fsx(`inline-flex w-fit flex-row items-center gap-1`, className)}>
       <MuiRadio
@@ -48,3 +48,5 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
     </Text>
   ),
 );
+
+export type RadioProps = ComponentPropsWithRef<typeof Radio>


### PR DESCRIPTION
## チケット

- Close #1559 

## 実装内容

- Radio, CheckboxのProps型をrefが正しく `HTMLInputElement` に推論されるように修正

## スクリーンショット

| 変更前 | 変更後 |
| ------ | ------ |
|        |        |

## 相談内容(あれば)

-
